### PR TITLE
feat: application, dev, prod 설정파일 yml 추가

### DIFF
--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -1,0 +1,24 @@
+spring:
+  config:
+    activate:
+      on-profile: dev
+  jpa:
+    hibernate:
+      ddl-auto: create-drop
+    defer-datasource-initialization: true
+    show-sql: true
+  h2:
+    console:
+      enabled: true
+      settings:
+        web-allow-others: true
+      path: /h2-console
+  datasource:
+    driver-class-name: org.h2.Driver
+    url: jdbc:h2:mem:test
+    username: sa
+    password:
+#  sql:
+#    init:
+#      mode: always
+#      data-locations: classpath:data-dev.sql

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -1,0 +1,20 @@
+spring:
+  config:
+    activate:
+      on-profile: prod
+  jpa:
+    hibernate:
+      ddl-auto: update
+    defer-datasource-initialization: true
+    show-sql: false
+  datasource:
+    driver-class-name: com.mysql.cj.jdbc.Driver
+    url: ${DB_URL}
+    username: ${DB_USERNAME}
+    password: ${DB_PASSWORD}
+  sql:
+    init:
+      mode: never
+      encoding: UTF-8
+      data-locations: classpath:data-prod.sql  # 기본 경로 유지
+

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,0 @@
-spring.application.name=Ururu

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,3 @@
+spring:
+  profiles:
+    active: dev


### PR DESCRIPTION
## ⭐️ Issue Number
- #3 

## 🚩 Summary
- application.yml 파일과 dev, prod 파일 추가 했습니다.
- dev, prod 같은 경우 각각 h2, MySQL에 관련된 설정을 넣어 뒀습니다.
- dev, prod에 있는 해당 코드 같은 경우는 목 데이터를 넣었을 경우를 위해서 적었고 일단 주석 처리를 했습니다.
```
sql:
#    init:
#      mode: always
#      data-locations: classpath:data-dev.sql
```

## 🛠️ Technical Concerns


## 🙂 To Reviewer


## 📋 To Do

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added separate configuration files for development and production environments, enabling easier environment-specific setup.
  - Enabled an embedded H2 database console for development, accessible via web browser.
- **Chores**
  - Set the default application profile to "dev".
  - Removed the application name property from the configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->