### PR TITLE
SecurityConfig header설정 추가 - h2콘솔 문제 해결

### DIFF
--- a/src/main/java/com/ururulab/ururu/global/config/SecurityConfig.java
+++ b/src/main/java/com/ururulab/ururu/global/config/SecurityConfig.java
@@ -27,6 +27,11 @@ public class SecurityConfig {
                 )
                 .csrf(AbstractHttpConfigurer::disable
                 )
+                .headers(headers -> headers
+                        .frameOptions(frameOptions -> frameOptions.disable()) // H2 콘솔의 iframe 허용
+                        .contentTypeOptions(contentType -> contentType.disable())
+                        .httpStrictTransportSecurity(hstsConfig -> hstsConfig.disable())
+                )
                 .sessionManagement(session ->
                         session.sessionCreationPolicy(SessionCreationPolicy.STATELESS)
                 );


### PR DESCRIPTION
## ⭐️ Issue Number
- #16

## 🚩 Summary
- SecurityConfig설정 문제로 H2콘솔 페이지 깨짐

## 🛠️ Technical Concerns


## 🙂 To Reviewer


## 📋 To Do