### PR TITLE
Product, ProductOption, ProductNotice Entity 수정

### DIFF
--- a/src/main/java/com/ururulab/ururu/product/domain/entity/Product.java
+++ b/src/main/java/com/ururulab/ururu/product/domain/entity/Product.java
@@ -41,7 +41,7 @@ public class Product extends BaseEntity {
     private List<ProductCategory> productCategories = new ArrayList<>();
 
     @OneToOne(mappedBy = "product", cascade = CascadeType.ALL, orphanRemoval = true)
-    private ProductNotice productNotices;
+    private ProductNotice productNotice;
 
     public static Product of(
             //Seller seller,

--- a/src/main/java/com/ururulab/ururu/product/domain/entity/Product.java
+++ b/src/main/java/com/ururulab/ururu/product/domain/entity/Product.java
@@ -40,6 +40,9 @@ public class Product extends BaseEntity {
     @OneToMany(mappedBy = "product", orphanRemoval = true)
     private List<ProductCategory> productCategories = new ArrayList<>();
 
+    @OneToOne(mappedBy = "product", cascade = CascadeType.ALL, orphanRemoval = true)
+    private ProductNotice productNotices;
+
     public static Product of(
             //Seller seller,
             String name,

--- a/src/main/java/com/ururulab/ururu/product/domain/entity/ProductNotice.java
+++ b/src/main/java/com/ururulab/ururu/product/domain/entity/ProductNotice.java
@@ -17,8 +17,8 @@ public class ProductNotice extends BaseEntity {
     private Long id;
 
     @OneToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "product_option_id")
-    private ProductOption productOption;
+    @JoinColumn(name = "product_id")
+    private Product product;
 
     @Column(nullable = false, length = 50)
     private String capacity; //용량
@@ -38,9 +38,6 @@ public class ProductNotice extends BaseEntity {
     @Column(nullable = false, length = 50)
     private String countryOfOrigin; //제조국
 
-    @Column(nullable = false, columnDefinition = "TEXT")
-    private String fullIngredients; // 전성분
-
     @Column(nullable = false)
     private boolean functionalCosmetics; // 기능성 여부
 
@@ -54,28 +51,26 @@ public class ProductNotice extends BaseEntity {
     private String customerServiceNumber; //고객센터 번호
 
     public static ProductNotice of(
-            ProductOption productOption,
+            Product product,
             String capacity,
             String expiry,
             String usage,
             String manufacturer,
             String responsibleSeller,
             String countryOfOrigin,
-            String fullIngredients,
             boolean functionalCosmetics,
             String caution,
             String warranty,
             String customerServiceNumber
     ){
         ProductNotice productNotice = new ProductNotice();
-        productNotice.productOption = productOption;
+        productNotice.product = product;
         productNotice.capacity = capacity;
         productNotice.expiry = expiry;
         productNotice.usage = usage;
         productNotice.manufacturer = manufacturer;
         productNotice.responsibleSeller = responsibleSeller;
         productNotice.countryOfOrigin = countryOfOrigin;
-        productNotice.fullIngredients = fullIngredients;
         productNotice.functionalCosmetics = functionalCosmetics;
         productNotice.caution = caution;
         productNotice.warranty = warranty;

--- a/src/main/java/com/ururulab/ururu/product/domain/entity/ProductNotice.java
+++ b/src/main/java/com/ururulab/ururu/product/domain/entity/ProductNotice.java
@@ -56,6 +56,7 @@ public class ProductNotice extends BaseEntity {
     public static ProductNotice of(
             Product product,
             String capacity,
+            String spec,
             String expiry,
             String usage,
             String manufacturer,
@@ -69,6 +70,7 @@ public class ProductNotice extends BaseEntity {
         ProductNotice productNotice = new ProductNotice();
         productNotice.product = product;
         productNotice.capacity = capacity;
+        productNotice.spec = spec;
         productNotice.expiry = expiry;
         productNotice.usage = usage;
         productNotice.manufacturer = manufacturer;

--- a/src/main/java/com/ururulab/ururu/product/domain/entity/ProductNotice.java
+++ b/src/main/java/com/ururulab/ururu/product/domain/entity/ProductNotice.java
@@ -23,6 +23,9 @@ public class ProductNotice extends BaseEntity {
     @Column(nullable = false, length = 50)
     private String capacity; //용량
 
+    @Column(nullable = false, length = 50)
+    private String spec; // 제품 주요 사양
+
     @Column(nullable = false, length = 100)
     private String expiry; // 사용기한
 

--- a/src/main/java/com/ururulab/ururu/product/domain/entity/ProductOption.java
+++ b/src/main/java/com/ururulab/ururu/product/domain/entity/ProductOption.java
@@ -39,15 +39,16 @@ public class ProductOption extends BaseEntity {
     @Column(nullable = false)
     private boolean isDeleted = false;
 
-    @OneToOne(mappedBy = "productOption", cascade = CascadeType.ALL, orphanRemoval = true)
-    private ProductNotice productNotice;
+    @Column(nullable = false, columnDefinition = "TEXT")
+    private String fullIngredients; // 전성분
 
     public static ProductOption of(
             Product product,
             String name,
             int price,
             String imageUrl,
-            Map<String,String> specifications
+            Map<String,String> specifications,
+            String fullIngredients
     ){
         ProductOption productOption = new ProductOption();
         productOption.product = product;
@@ -55,6 +56,7 @@ public class ProductOption extends BaseEntity {
         productOption.price = price;
         productOption.imageUrl = imageUrl;
         productOption.specifications = specifications;
+        productOption.fullIngredients = fullIngredients;
 
         return productOption;
     }

--- a/src/main/java/com/ururulab/ururu/product/domain/entity/ProductOption.java
+++ b/src/main/java/com/ururulab/ururu/product/domain/entity/ProductOption.java
@@ -5,10 +5,6 @@ import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.hibernate.annotations.JdbcTypeCode;
-import org.hibernate.type.SqlTypes;
-
-import java.util.Map;
 
 @Entity
 @Getter
@@ -32,10 +28,6 @@ public class ProductOption extends BaseEntity {
     @Column(nullable = true)
     private String imageUrl;
 
-    @JdbcTypeCode(SqlTypes.JSON)
-    @Column(nullable = true, columnDefinition = "JSON")
-    private Map<String, String> specifications;
-
     @Column(nullable = false)
     private boolean isDeleted = false;
 
@@ -47,7 +39,6 @@ public class ProductOption extends BaseEntity {
             String name,
             int price,
             String imageUrl,
-            Map<String,String> specifications,
             String fullIngredients
     ){
         ProductOption productOption = new ProductOption();
@@ -55,7 +46,6 @@ public class ProductOption extends BaseEntity {
         productOption.name = name;
         productOption.price = price;
         productOption.imageUrl = imageUrl;
-        productOption.specifications = specifications;
         productOption.fullIngredients = fullIngredients;
 
         return productOption;

--- a/src/main/java/com/ururulab/ururu/product/domain/repository/ProductRepository.java
+++ b/src/main/java/com/ururulab/ururu/product/domain/repository/ProductRepository.java
@@ -34,6 +34,6 @@ public interface ProductRepository extends JpaRepository<Product, Long> {
     Optional<Product> findByIdWithOptions(@Param("productId") Long productId);
 
     //상품 + 정보고시 함께 조회 -> 엔티티 구조 변경 후 주석 제거
-    @Query("SELECT p FROM Product p LEFT JOIN FETCH p.productNotices WHERE p.id = :productId")
+    @Query("SELECT p FROM Product p LEFT JOIN FETCH p.productNotice WHERE p.id = :productId")
     Optional<Product> findByIdWithNotice(@Param("productId") Long productId);
 }

--- a/src/main/java/com/ururulab/ururu/product/domain/repository/ProductRepository.java
+++ b/src/main/java/com/ururulab/ururu/product/domain/repository/ProductRepository.java
@@ -33,7 +33,7 @@ public interface ProductRepository extends JpaRepository<Product, Long> {
     @Query("SELECT p FROM Product p LEFT JOIN FETCH p.productOptions po WHERE p.id = :productId AND po.isDeleted = false")
     Optional<Product> findByIdWithOptions(@Param("productId") Long productId);
 
-    // 상품 + 정보고시 함께 조회 -> 엔티티 구조 변경 후 주석 제거
-//    @Query("SELECT p FROM Product p LEFT JOIN FETCH p.productNotice WHERE p.id = :productId")
-//    Optional<Product> findByIdWithNotice(@Param("productId") Long productId);
+    //상품 + 정보고시 함께 조회 -> 엔티티 구조 변경 후 주석 제거
+    @Query("SELECT p FROM Product p LEFT JOIN FETCH p.productNotices WHERE p.id = :productId")
+    Optional<Product> findByIdWithNotice(@Param("productId") Long productId);
 }


### PR DESCRIPTION
## ⭐️ Issue Number
- #30 

## 🚩 Summary
- Product와 ProductNotice Entity 1 : 1 매핑으로 변경
- ProductNotice에 있던 전성분 컬럼 ProductOption으로 이동

## 🛠️ Technical Concerns


## 🙂 To Reviewer
Product, ProductNotice 관계가 1 : 1 매핑이 제대로 되었는지와 ProductOption에 전성분 컬럼이 추가되고 ProductNotice Entity에는 제대로 제거가 되었는지를 중점적으로 봐주시면 감사하겠습니다 :)

## 📋 To Do

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
  - 상품과 상품 공지사항 간의 연관 관계가 추가되어, 상품 조회 시 관련 공지사항 정보를 함께 확인할 수 있습니다.
  - 상품 공지사항에 제품 사양(spec) 정보가 새롭게 추가되었습니다.

- **변경 사항**
  - 상품 옵션의 전체 성분 정보가 별도 필드로 분리되어 관리됩니다.
  - 상품 옵션과 상품 공지사항 간의 관계 구조가 변경되었습니다.
  - 상품 공지사항에서 전체 성분(fullIngredients) 필드가 제거되고, 상품 옵션으로 이동되었습니다.

- **버그 수정**
  - 상품과 공지사항을 함께 조회할 수 있는 기능이 개선되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->