### PR TITLE
장바구니/주문 관련 도메인 설계

### DIFF
--- a/src/main/java/com/ururulab/ururu/order/domain/entity/Cart.java
+++ b/src/main/java/com/ururulab/ururu/order/domain/entity/Cart.java
@@ -47,6 +47,9 @@ public class Cart extends BaseEntity {
     }
 
     public void removeItem(CartItem cartItem) {
+        if (cartItem == null) {
+            throw new IllegalArgumentException("장바구니 아이템은 필수입니다.");
+        }
         cartItems.remove(cartItem);
     }
 

--- a/src/main/java/com/ururulab/ururu/order/domain/entity/Cart.java
+++ b/src/main/java/com/ururulab/ururu/order/domain/entity/Cart.java
@@ -1,0 +1,73 @@
+package com.ururulab.ururu.order.domain.entity;
+
+import com.ururulab.ururu.global.common.entity.BaseEntity;
+import com.ururulab.ururu.member.domain.entity.Member;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Getter
+@Table(name = "cart")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Cart extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+
+    @OneToMany(mappedBy = "cart", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<CartItem> cartItems = new ArrayList<>();
+
+    public static Cart create(Member member) {
+        if (member == null) {
+            throw new IllegalArgumentException("회원 정보는 필수입니다.");
+        }
+
+        Cart cart = new Cart();
+        cart.member = member;
+        return cart;
+    }
+
+    public void addItem(CartItem cartItem) {
+        if (cartItem == null) {
+            throw new IllegalArgumentException("장바구니 아이템은 필수입니다.");
+        }
+
+        cartItems.add(cartItem);
+        cartItem.assignCart(this);
+    }
+
+    public void removeItem(CartItem cartItem) {
+        cartItems.remove(cartItem);
+    }
+
+    public void removeItem(Long cartItemId) {
+        if (cartItemId == null) {
+            throw new IllegalArgumentException("장바구니 아이템 ID는 필수입니다.");
+        }
+        cartItems.removeIf(item -> item.getId().equals(cartItemId));
+    }
+
+    public void clearItems() {
+        cartItems.clear();
+    }
+
+    public int getTotalItemCount() {
+        return cartItems.stream()
+                .mapToInt(CartItem::getQuantity)
+                .sum();
+    }
+
+    public boolean isEmpty() {
+        return cartItems.isEmpty();
+    }
+}

--- a/src/main/java/com/ururulab/ururu/order/domain/entity/Cart.java
+++ b/src/main/java/com/ururulab/ururu/order/domain/entity/Cart.java
@@ -57,7 +57,7 @@ public class Cart extends BaseEntity {
         if (cartItemId == null) {
             throw new IllegalArgumentException("장바구니 아이템 ID는 필수입니다.");
         }
-        cartItems.removeIf(item -> item.getId().equals(cartItemId));
+        cartItems.removeIf(item -> item.getId() != null && item.getId().equals(cartItemId));
     }
 
     public void clearItems() {

--- a/src/main/java/com/ururulab/ururu/order/domain/entity/CartItem.java
+++ b/src/main/java/com/ururulab/ururu/order/domain/entity/CartItem.java
@@ -1,0 +1,75 @@
+package com.ururulab.ururu.order.domain.entity;
+
+import com.ururulab.ururu.global.common.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Table(name = "cart_item")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class CartItem extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "cart_id", nullable = false)
+    private Cart cart;
+
+    // TODO: GroupBuyOption 엔티티 완성 후 연관관계로 변경
+    // @ManyToOne(fetch = FetchType.LAZY)
+    // @JoinColumn(name = "groupbuy_option_id", nullable = false)
+    // private GroupBuyOption groupBuyOption;
+
+    @Column(name = "groupbuy_option_id", nullable = false)
+    private Long groupBuyOptionId;
+
+    @Column(nullable = false)
+    private int quantity;
+
+    public static CartItem create(Long groupBuyOptionId, int quantity) {
+        if (groupBuyOptionId == null) {
+            throw new IllegalArgumentException("공동구매 상품 옵션 ID는 필수입니다.");
+        }
+        if (quantity <= 0) {
+            throw new IllegalArgumentException("수량은 1 이상이어야 합니다.");
+        }
+
+        CartItem cartItem = new CartItem();
+        cartItem.groupBuyOptionId = groupBuyOptionId;
+        cartItem.quantity = quantity;
+        return cartItem;
+    }
+
+    public void assignCart(Cart cart) {
+        this.cart = cart;
+    }
+
+    public void updateQuantity(int quantity) {
+        if (quantity <= 0) {
+            throw new IllegalArgumentException("수량은 1 이상이어야 합니다.");
+        }
+        this.quantity = quantity;
+    }
+
+    public void increaseQuantity(int amount) {
+        if (amount <= 0) {
+            throw new IllegalArgumentException("증가량은 1 이상이어야 합니다.");
+        }
+        this.quantity += amount;
+    }
+
+    public void decreaseQuantity(int amount) {
+        if (amount <= 0) {
+            throw new IllegalArgumentException("감소량은 1 이상이어야 합니다.");
+        }
+        if (this.quantity - amount < 0) {
+            throw new IllegalArgumentException("수량은 0 미만이 될 수 없습니다.");
+        }
+        this.quantity -= amount;
+    }
+}

--- a/src/main/java/com/ururulab/ururu/order/domain/entity/Order.java
+++ b/src/main/java/com/ururulab/ururu/order/domain/entity/Order.java
@@ -1,0 +1,125 @@
+package com.ururulab.ururu.order.domain.entity;
+
+import com.ururulab.ururu.global.common.entity.BaseEntity;
+import com.ururulab.ururu.member.domain.entity.Member;
+import com.ururulab.ururu.order.domain.entity.enumerated.OrderStatus;
+import com.ururulab.ururu.order.domain.entity.enumerated.PaymentStatus;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+@Entity
+@Getter
+@Table(name = "order")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Order extends BaseEntity {
+
+    @Id
+    @Column(length = 36)
+    private String id;
+
+    // TODO: GroupBuy 엔티티 완성 후 연관관계로 변경
+    // @ManyToOne(fetch = FetchType.LAZY)
+    // @JoinColumn(name = "groupbuy_id", nullable = false)
+    // private GroupBuy groupBuy;
+
+    @Column(name = "groupbuy_id", nullable = false)
+    private Long groupBuyId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private OrderStatus status;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private PaymentStatus paymentStatus;
+
+    @Column(length = 20, nullable = false)
+    private String phone;
+
+    @Column(length = 5, nullable = false)
+    private String zonecode;
+
+    @Column(length = 255, nullable = false)
+    private String address1;
+
+    @Column(length = 255)
+    private String address2;
+
+    @Column(length = 50)
+    private String trackingNumber;
+
+    @OneToMany(mappedBy = "order", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<OrderItem> orderItems = new ArrayList<>();
+
+    @OneToMany(mappedBy = "order", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<OrderHistory> orderHistories = new ArrayList<>();
+
+    public static Order create(
+            Long groupBuyId,
+            Member member,
+            String phone,
+            String zonecode,
+            String address1,
+            String address2
+    ) {
+        if (groupBuyId == null) {
+            throw new IllegalArgumentException("공동구매 ID는 필수입니다.");
+        }
+        if (member == null) {
+            throw new IllegalArgumentException("회원 정보는 필수입니다.");
+        }
+
+        Order order = new Order();
+        order.id = UUID.randomUUID().toString();
+        order.groupBuyId = groupBuyId;
+        order.member = member;
+        order.status = OrderStatus.ORDERED;
+        order.paymentStatus = PaymentStatus.PENDING;
+        order.phone = phone;
+        order.zonecode = zonecode;
+        order.address1 = address1;
+        order.address2 = address2;
+
+        order.addOrderHistory(OrderStatus.ORDERED, "주문이 생성되었습니다.");
+
+        return order;
+    }
+
+    public void addOrderItem(OrderItem orderItem) {
+        if (orderItem == null) {
+            throw new IllegalArgumentException("주문 아이템은 필수입니다.");
+        }
+        orderItems.add(orderItem);
+        orderItem.assignOrder(this);
+    }
+
+    public void addOrderHistory(OrderStatus status, String comment) {
+        OrderHistory history = OrderHistory.create(this, status, comment);
+        orderHistories.add(history);
+    }
+
+    public void changeStatus(OrderStatus status, String reason) {
+        if (status == null) {
+            throw new IllegalArgumentException("주문 상태는 필수입니다.");
+        }
+        this.status = status;
+        addOrderHistory(status, reason);
+    }
+
+    public void changePaymentStatus(PaymentStatus paymentStatus) {
+        if (paymentStatus == null) {
+            throw new IllegalArgumentException("결제 상태는 필수입니다.");
+        }
+        this.paymentStatus = paymentStatus;
+    }
+}

--- a/src/main/java/com/ururulab/ururu/order/domain/entity/OrderHistory.java
+++ b/src/main/java/com/ururulab/ururu/order/domain/entity/OrderHistory.java
@@ -1,0 +1,45 @@
+package com.ururulab.ururu.order.domain.entity;
+
+import com.ururulab.ururu.global.common.entity.BaseEntity;
+import com.ururulab.ururu.order.domain.entity.enumerated.OrderStatus;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Table(name = "order_history")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class OrderHistory extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "order_id", nullable = false)
+    private Order order;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private OrderStatus status;
+
+    @Column(length = 255)
+    private String comment;
+
+    public static OrderHistory create(Order order, OrderStatus status, String comment) {
+        if (order == null) {
+            throw new IllegalArgumentException("주문 정보는 필수입니다.");
+        }
+        if (status == null) {
+            throw new IllegalArgumentException("주문 상태는 필수입니다.");
+        }
+
+        OrderHistory history = new OrderHistory();
+        history.order = order;
+        history.status = status;
+        history.comment = comment;
+        return history;
+    }
+}

--- a/src/main/java/com/ururulab/ururu/order/domain/entity/OrderItem.java
+++ b/src/main/java/com/ururulab/ururu/order/domain/entity/OrderItem.java
@@ -1,0 +1,51 @@
+package com.ururulab.ururu.order.domain.entity;
+
+import com.ururulab.ururu.global.common.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Table(name = "order_item")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class OrderItem extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "order_id", nullable = false)
+    private Order order;
+
+    // TODO: GroupBuyOption 엔티티 완성 후 연관관계로 변경
+    // @ManyToOne(fetch = FetchType.LAZY)
+    // @JoinColumn(name = "groupbuy_option_id", nullable = false)
+    // private GroupBuyOption groupBuyOption;
+
+    @Column(name = "groupbuy_option_id", nullable = false)
+    private Long groupBuyOptionId;
+
+    @Column(nullable = false)
+    private int quantity;
+
+    public static OrderItem create(Long groupBuyOptionId, int quantity) {
+        if (groupBuyOptionId == null) {
+            throw new IllegalArgumentException("공동구매 옵션 ID는 필수입니다.");
+        }
+        if (quantity <= 0) {
+            throw new IllegalArgumentException("수량은 1 이상이어야 합니다.");
+        }
+
+        OrderItem orderItem = new OrderItem();
+        orderItem.groupBuyOptionId = groupBuyOptionId;
+        orderItem.quantity = quantity;
+        return orderItem;
+    }
+
+    public void assignOrder(Order order) {
+        this.order = order;
+    }
+}

--- a/src/main/java/com/ururulab/ururu/order/domain/entity/enumerated/OrderStatus.java
+++ b/src/main/java/com/ururulab/ururu/order/domain/entity/enumerated/OrderStatus.java
@@ -1,0 +1,13 @@
+package com.ururulab.ururu.order.domain.entity.enumerated;
+
+import com.ururulab.ururu.global.common.entity.enumerated.EnumParser;
+
+public enum OrderStatus {
+    ORDERED,    // 주문 완료
+    CANCELLED,  // 주문 취소
+    REFUNDED;   // 환불 완료
+
+    public static OrderStatus from(String value) {
+        return EnumParser.fromString(OrderStatus.class, value, "OrderStatus");
+    }
+}

--- a/src/main/java/com/ururulab/ururu/order/domain/entity/enumerated/PaymentStatus.java
+++ b/src/main/java/com/ururulab/ururu/order/domain/entity/enumerated/PaymentStatus.java
@@ -1,0 +1,14 @@
+package com.ururulab.ururu.order.domain.entity.enumerated;
+
+import com.ururulab.ururu.global.common.entity.enumerated.EnumParser;
+
+public enum PaymentStatus {
+    PENDING,    // 결제 대기
+    PAID,       // 결제 완료
+    REFUNDED,   // 환불 완료
+    FAILED;     // 결제 실패
+
+    public static PaymentStatus from(String value) {
+        return EnumParser.fromString(PaymentStatus.class, value, "PaymentStatus");
+    }
+}


### PR DESCRIPTION
## ⭐️ Issue Number
- #36 

## 🚩 Summary
- Order 도메인 엔티티 구조 설계 및 구현
- OrderStatus, PaymentStatus Enum 추가
- Cart, CartItem, Order, OrderItem, OrderHistory 엔티티 생성
- 양방향 연관관계 설정 및 cascade 처리

## 🛠️ Technical Concerns
- GroupBuy, GroupBuyOption 엔티티 미완성으로 임시 ID 참조 (TODO 주석 처리)
- 단순한 상태 변경 메서드만 구현

## 🙂 To Reviewer
- Order 도메인 내 엔티티들의 일관성 있는 코드 스타일 확인 요청
- TODO 주석 처리된 GroupBuy, GroupBuyOption 연관관계 확인

## 📋 To Do
 - Repository 인터페이스 구현
 - Service 계층 구현
 - DTO 클래스 설계

## Summary by CodeRabbit
- **신규 기능**
    - 장바구니, 장바구니 아이템, 주문, 주문 아이템, 주문 내역 등 주문 관련 엔티티가 추가되었습니다.
    - 주문 상태(주문 완료, 취소, 환불)와 결제 상태(대기, 결제 완료, 환불, 실패)를 나타내는 새로운 열거형(enum)이 도입되었습니다.
    - 장바구니 및 주문 내 아이템 추가, 수량 변경, 상태 변경, 주문 내역 기록 등 다양한 기능이 제공됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->