### PR TITLE
Member Controller 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,6 +44,9 @@ dependencies {
 
     implementation 'org.springframework.boot:spring-boot-starter-webflux'
     testImplementation 'io.projectreactor:reactor-test'
+
+    // https://mvnrepository.com/artifact/org.springdoc/springdoc-openapi-starter-webmvc-ui
+    implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.8")
 }
 
 tasks.named('test') {

--- a/src/main/java/com/ururulab/ururu/auth/controller/AuthController.java
+++ b/src/main/java/com/ururulab/ururu/auth/controller/AuthController.java
@@ -5,7 +5,7 @@ import com.ururulab.ururu.auth.dto.response.SocialLoginResponse;
 import com.ururulab.ururu.auth.jwt.JwtTokenProvider;
 import com.ururulab.ururu.auth.service.SocialLoginService;
 import com.ururulab.ururu.auth.service.SocialLoginServiceFactory;
-import com.ururulab.ururu.global.common.dto.ApiResponse;
+import com.ururulab.ururu.global.common.dto.ApiResponseFormat;
 import com.ururulab.ururu.member.domain.entity.enumerated.SocialProvider;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -42,7 +42,7 @@ public final class AuthController {
     private final JwtTokenProvider jwtTokenProvider;
 
     @PostMapping("/social/sessions")
-    public ResponseEntity<ApiResponse<SocialLoginResponse>> socialLogin(
+    public ResponseEntity<ApiResponseFormat<SocialLoginResponse>> socialLogin(
             @Valid @RequestBody final SocialLoginRequest request
     ) {
         try {
@@ -53,19 +53,19 @@ public final class AuthController {
                     request.provider(), loginResponse.memberInfo().memberId());
 
             return ResponseEntity.ok(
-                    ApiResponse.success("소셜 로그인에 성공했습니다.", loginResponse)
+                    ApiResponseFormat.success("소셜 로그인에 성공했습니다.", loginResponse)
             );
 
         } catch (final Exception e) {
             log.error("Social login failed for provider: {}", request.provider(), e);
             return ResponseEntity.badRequest()
-                    .body(ApiResponse.fail("소셜 로그인에 실패했습니다: " + e.getMessage()));
+                    .body(ApiResponseFormat.fail("소셜 로그인에 실패했습니다: " + e.getMessage()));
         }
     }
 
 
     @GetMapping("/social/providers")
-    public ResponseEntity<ApiResponse<GetSocialProvidersResponse>> getSocialProviders() {
+    public ResponseEntity<ApiResponseFormat<GetSocialProvidersResponse>> getSocialProviders() {
         final List<SocialProviderInfo> providers = Arrays.stream(SocialProvider.values())
                 .map(provider -> SocialProviderInfo.of(
                         provider.name().toLowerCase(),
@@ -78,7 +78,7 @@ public final class AuthController {
         final GetSocialProvidersResponse response = GetSocialProvidersResponse.of(providers);
 
         return ResponseEntity.ok(
-                ApiResponse.success("지원 소셜 로그인 목록을 조회했습니다.", response)
+                ApiResponseFormat.success("지원 소셜 로그인 목록을 조회했습니다.", response)
         );
     }
 
@@ -115,20 +115,20 @@ public final class AuthController {
     }
 
     @PostMapping("/logout")
-    public ResponseEntity<ApiResponse<Void>> logout() {
+    public ResponseEntity<ApiResponseFormat<Void>> logout() {
         log.info("Member logout requested");
         return ResponseEntity.ok(
-                ApiResponse.success("로그아웃되었습니다.")
+                ApiResponseFormat.success("로그아웃되었습니다.")
         );
     }
 
     @GetMapping("/status")
-    public ResponseEntity<ApiResponse<AuthStatusResponse>> getAuthStatus(
+    public ResponseEntity<ApiResponseFormat<AuthStatusResponse>> getAuthStatus(
             @RequestHeader(value = "Authorization", required = false) final String authorization) {
 
         if (authorization == null || !authorization.startsWith("Bearer ")) {
             return ResponseEntity.ok(
-                    ApiResponse.success("인증되지 않은 상태입니다.",
+                    ApiResponseFormat.success("인증되지 않은 상태입니다.",
                             AuthStatusResponse.unauthenticated())
             );
         }
@@ -141,17 +141,17 @@ public final class AuthController {
 
             if (jwtTokenProvider.validateToken(token)) {
                 return ResponseEntity.ok(
-                        ApiResponse.success("인증된 상태입니다.",
+                        ApiResponseFormat.success("인증된 상태입니다.",
                                 AuthStatusResponse.authenticated(memberId, email, role))
                 );
             } else {
                 return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
-                        .body(ApiResponse.fail("토큰이 유효하지 않습니다."));
+                        .body(ApiResponseFormat.fail("토큰이 유효하지 않습니다."));
             }
         } catch (final Exception e) {
             log.warn("Token validation failed: {}", e.getMessage());
             return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
-                    .body(ApiResponse.fail("토큰 검증에 실패했습니다."));
+                    .body(ApiResponseFormat.fail("토큰 검증에 실패했습니다."));
         }
     }
 

--- a/src/main/java/com/ururulab/ururu/global/common/dto/ApiResponseFormat.java
+++ b/src/main/java/com/ururulab/ururu/global/common/dto/ApiResponseFormat.java
@@ -11,14 +11,14 @@ import lombok.Getter;
  * @param <T> 응답 데이터 타입
  */
 @Getter
-public final class ApiResponse<T> {
+public final class ApiResponseFormat<T> {
 
     private final boolean success;   // 요청 성공 여부
     private final String message;    // 응답 메시지
     @JsonInclude(JsonInclude.Include.NON_NULL)
     private final T data;            // 실제 응답 데이터 (null 가능)
 
-    private ApiResponse(final boolean success, final String message, final T data) {
+    private ApiResponseFormat(final boolean success, final String message, final T data) {
         this.success = success;
         this.message = message;
         this.data = data;
@@ -32,8 +32,8 @@ public final class ApiResponse<T> {
      * @param data 응답 데이터
      * @return 성공 응답
      */
-    public static <T> ApiResponse<T> success(final String message, final T data) {
-        return new ApiResponse<>(true, message, data);
+    public static <T> ApiResponseFormat<T> success(final String message, final T data) {
+        return new ApiResponseFormat<>(true, message, data);
     }
 
     /**
@@ -43,8 +43,8 @@ public final class ApiResponse<T> {
      * @param message 성공 메시지
      * @return 데이터가 없는 성공 응답
      */
-    public static <T> ApiResponse<T> success(final String message) {
-        return new ApiResponse<>(true, message, null);
+    public static <T> ApiResponseFormat<T> success(final String message) {
+        return new ApiResponseFormat<>(true, message, null);
     }
 
     /**
@@ -54,7 +54,7 @@ public final class ApiResponse<T> {
      * @param message 실패 메시지
      * @return 실패 응답
      */
-    public static <T> ApiResponse<T> fail(final String message) {
-        return new ApiResponse<>(false, message, null);
+    public static <T> ApiResponseFormat<T> fail(final String message) {
+        return new ApiResponseFormat<>(false, message, null);
     }
 }

--- a/src/main/java/com/ururulab/ururu/global/config/SwaggerConfig.java
+++ b/src/main/java/com/ururulab/ururu/global/config/SwaggerConfig.java
@@ -1,0 +1,17 @@
+package com.ururulab.ururu.global.config;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SwaggerConfig {
+    @Bean
+    public OpenAPI customOpenAPI() {
+        return new OpenAPI()
+                .info(new Info().title("Ururu Server API")
+                        .version("1.0.0")
+                        .description("우르르 서버 API 문서"));
+    }
+}

--- a/src/main/java/com/ururulab/ururu/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/ururulab/ururu/global/exception/GlobalExceptionHandler.java
@@ -4,7 +4,7 @@ import com.ururulab.ururu.auth.exception.SocialLoginException;
 import com.ururulab.ururu.auth.exception.SocialTokenExchangeException;
 import com.ururulab.ururu.auth.exception.SocialMemberInfoException;
 import com.ururulab.ururu.auth.exception.UnsupportedSocialProviderException;
-import com.ururulab.ururu.global.common.dto.ApiResponse;
+import com.ururulab.ururu.global.common.dto.ApiResponseFormat;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -26,59 +26,59 @@ public final class GlobalExceptionHandler {
      * 지원하지 않는 소셜 제공자 예외 처리.
      */
     @ExceptionHandler(UnsupportedSocialProviderException.class)
-    public ResponseEntity<ApiResponse<Void>> handleUnsupportedSocialProvider(
+    public ResponseEntity<ApiResponseFormat<Void>> handleUnsupportedSocialProvider(
             final UnsupportedSocialProviderException exception
     ) {
         log.warn("Unsupported social provider: {}", exception.getMessage());
         return ResponseEntity
                 .status(HttpStatus.BAD_REQUEST)
-                .body(ApiResponse.fail(exception.getMessage()));
+                .body(ApiResponseFormat.fail(exception.getMessage()));
     }
 
     /**
      * 소셜 토큰 교환 실패 예외 처리.
      */
     @ExceptionHandler(SocialTokenExchangeException.class)
-    public ResponseEntity<ApiResponse<Void>> handleSocialTokenExchange(
+    public ResponseEntity<ApiResponseFormat<Void>> handleSocialTokenExchange(
             final SocialTokenExchangeException exception
     ) {
         log.error("Social token exchange failed: {}", exception.getMessage(), exception);
         return ResponseEntity
                 .status(HttpStatus.UNAUTHORIZED)
-                .body(ApiResponse.fail("소셜 로그인 인증에 실패했습니다."));
+                .body(ApiResponseFormat.fail("소셜 로그인 인증에 실패했습니다."));
     }
 
     /**
      * 소셜 회원 정보 조회 실패 예외 처리.
      */
     @ExceptionHandler(SocialMemberInfoException.class)
-    public ResponseEntity<ApiResponse<Void>> handleSocialMemberInfo(
+    public ResponseEntity<ApiResponseFormat<Void>> handleSocialMemberInfo(
             final SocialMemberInfoException exception
     ) {
         log.error("Social member info retrieval failed: {}", exception.getMessage(), exception);
         return ResponseEntity
                 .status(HttpStatus.UNAUTHORIZED)
-                .body(ApiResponse.fail("회원 정보를 가져올 수 없습니다."));
+                .body(ApiResponseFormat.fail("회원 정보를 가져올 수 없습니다."));
     }
 
     /**
      * 일반적인 소셜 로그인 예외 처리.
      */
     @ExceptionHandler(SocialLoginException.class)
-    public ResponseEntity<ApiResponse<Void>> handleSocialLogin(
+    public ResponseEntity<ApiResponseFormat<Void>> handleSocialLogin(
             final SocialLoginException exception
     ) {
         log.error("Social login failed: {}", exception.getMessage(), exception);
         return ResponseEntity
                 .status(HttpStatus.INTERNAL_SERVER_ERROR)
-                .body(ApiResponse.fail("소셜 로그인 처리 중 오류가 발생했습니다."));
+                .body(ApiResponseFormat.fail("소셜 로그인 처리 중 오류가 발생했습니다."));
     }
 
     /**
      * 요청 데이터 검증 실패 예외 처리.
      */
     @ExceptionHandler(MethodArgumentNotValidException.class)
-    public ResponseEntity<ApiResponse<Void>> handleValidation(
+    public ResponseEntity<ApiResponseFormat<Void>> handleValidation(
             final MethodArgumentNotValidException exception
     ) {
         final String errorMessage = exception.getBindingResult()
@@ -91,30 +91,30 @@ public final class GlobalExceptionHandler {
         log.warn("Validation failed: {}", errorMessage);
         return ResponseEntity
                 .status(HttpStatus.BAD_REQUEST)
-                .body(ApiResponse.fail(errorMessage));
+                .body(ApiResponseFormat.fail(errorMessage));
     }
 
     /**
      * IllegalArgumentException 처리.
      */
     @ExceptionHandler(IllegalArgumentException.class)
-    public ResponseEntity<ApiResponse<Void>> handleIllegalArgument(
+    public ResponseEntity<ApiResponseFormat<Void>> handleIllegalArgument(
             final IllegalArgumentException exception
     ) {
         log.warn("Invalid argument: {}", exception.getMessage());
         return ResponseEntity
                 .status(HttpStatus.BAD_REQUEST)
-                .body(ApiResponse.fail(exception.getMessage()));
+                .body(ApiResponseFormat.fail(exception.getMessage()));
     }
 
     /**
      * 예상하지 못한 모든 예외 처리.
      */
     @ExceptionHandler(Exception.class)
-    public ResponseEntity<ApiResponse<Void>> handleGeneral(final Exception exception) {
+    public ResponseEntity<ApiResponseFormat<Void>> handleGeneral(final Exception exception) {
         log.error("Unexpected error occurred: {}", exception.getMessage(), exception);
         return ResponseEntity
                 .status(HttpStatus.INTERNAL_SERVER_ERROR)
-                .body(ApiResponse.fail("서버 내부 오류가 발생했습니다."));
+                .body(ApiResponseFormat.fail("서버 내부 오류가 발생했습니다."));
     }
 }

--- a/src/main/java/com/ururulab/ururu/member/controller/MemberController.java
+++ b/src/main/java/com/ururulab/ururu/member/controller/MemberController.java
@@ -9,8 +9,10 @@ import com.ururulab.ururu.member.domain.dto.response.UpdateMyProfileResponse;
 import com.ururulab.ururu.member.service.MemberService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
 @RestController
 @RequestMapping("/api/members")
@@ -59,6 +61,26 @@ public class MemberController {
         final UpdateMyProfileResponse response = memberService.updateMyProfile(memberId, request);
         return ResponseEntity.ok(
                 ApiResponse.success("내 정보를 수정했습니다.", response)
+        );
+    }
+
+    @PostMapping("/{memberId}/profile-images")
+    public ResponseEntity<ApiResponse<Void>> uploadProfileImage(
+            @PathVariable final Long memberId,
+            @RequestParam("imageFile") final MultipartFile imageFile
+    ) {
+        memberService.uploadProfileImage(memberId, imageFile);
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(ApiResponse.success("프로필 이미지를 업로드했습니다."));
+    }
+
+    @DeleteMapping("/{memberId}/profile-images")
+    public ResponseEntity<ApiResponse<Void>> deleteProfileImage(
+            @PathVariable final Long memberId
+    ) {
+        memberService.deleteProfileImage(memberId);
+        return ResponseEntity.ok(
+                ApiResponse.success("프로필 이미지를 삭제했습니다.")
         );
     }
 }

--- a/src/main/java/com/ururulab/ururu/member/controller/MemberController.java
+++ b/src/main/java/com/ururulab/ururu/member/controller/MemberController.java
@@ -1,0 +1,29 @@
+package com.ururulab.ururu.member.controller;
+
+import com.ururulab.ururu.global.common.dto.ApiResponse;
+import com.ururulab.ururu.member.domain.dto.response.GetMemberResponse;
+import com.ururulab.ururu.member.service.MemberService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/members")
+@RequiredArgsConstructor
+public class MemberController {
+
+    private final MemberService memberService;
+
+    @GetMapping("/{memberId}")
+    public ResponseEntity<ApiResponse<GetMemberResponse>> getMemberProfile(
+        @PathVariable final Long memberId
+    ) {
+        final GetMemberResponse response = memberService.getMemberProfile(memberId);
+        return ResponseEntity.ok(
+                ApiResponse.success("회원 정보를 조회했습니다.", response)
+        );
+    }
+}

--- a/src/main/java/com/ururulab/ururu/member/controller/MemberController.java
+++ b/src/main/java/com/ururulab/ururu/member/controller/MemberController.java
@@ -189,24 +189,13 @@ public class MemberController {
     @DeleteMapping("/{memberId}")
     @PreAuthorize("hasRole('ADMIN')")
     public ResponseEntity<ApiResponseFormat<Void>> deleteMember(
-            @PathVariable final Long memberId) {
+            @PathVariable final Long memberId
+    ) {
+        memberService.deleteMember(memberId);
+        return ResponseEntity.ok(
+                ApiResponseFormat.success("회원 탈퇴가 완료되었습니다.")
+        );
 
-        try {
-            memberService.deleteMember(memberId);
-            return ResponseEntity.ok(
-                    ApiResponseFormat.success("회원 탈퇴가 완료되었습니다.")
-            );
-        } catch (IllegalStateException e) {
-            // 탈퇴 불가능한 상태 (활성 주문 등)
-            log.warn("Member deletion failed due to business rule: {}", e.getMessage());
-            return ResponseEntity.badRequest()
-                    .body(ApiResponseFormat.fail(e.getMessage()));
-        } catch (Exception e) {
-            // 기타 시스템 오류
-            log.error("Unexpected error during member deletion for ID: {}", memberId, e);
-            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
-                    .body(ApiResponseFormat.fail("탈퇴 처리 중 오류가 발생했습니다."));
-        }
     }
 
     @Operation(summary = "회원 탈퇴", description = "현재 로그인한 회원이 스스로 탈퇴합니다.")
@@ -220,20 +209,10 @@ public class MemberController {
     public ResponseEntity<ApiResponseFormat<Void>> deleteMyAccount() {
         final Long memberId = getCurrentMemberId();
 
-        try {
-            memberService.deleteMember(memberId);
-            return ResponseEntity.ok(
-                    ApiResponseFormat.success("탈퇴가 완료되었습니다.")
-            );
-        } catch (IllegalStateException e) {
-            log.warn("Member self-deletion failed for ID {}: {}", memberId, e.getMessage());
-            return ResponseEntity.badRequest()
-                    .body(ApiResponseFormat.fail(e.getMessage()));
-        } catch (Exception e) {
-            log.error("Unexpected error during self-deletion for member ID: {}", memberId, e);
-            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
-                    .body(ApiResponseFormat.fail("탈퇴 처리 중 오류가 발생했습니다."));
-        }
+        memberService.deleteMember(memberId);
+        return ResponseEntity.ok(
+                ApiResponseFormat.success("탈퇴가 완료되었습니다.")
+        );
     }
 
     @Operation(summary = "탈퇴 미리보기", description = "회원 탈퇴 시 손실될 정보를 미리 확인합니다.")

--- a/src/main/java/com/ururulab/ururu/member/controller/MemberController.java
+++ b/src/main/java/com/ururulab/ururu/member/controller/MemberController.java
@@ -1,9 +1,13 @@
 package com.ururulab.ururu.member.controller;
 
-import com.ururulab.ururu.global.common.dto.ApiResponse;
+import com.ururulab.ururu.global.common.dto.ApiResponseFormat;
 import com.ururulab.ururu.member.domain.dto.request.MemberRequest;
 import com.ururulab.ururu.member.domain.dto.response.*;
 import com.ururulab.ururu.member.service.MemberService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -17,72 +21,112 @@ import org.springframework.web.multipart.MultipartFile;
 @RestController
 @RequestMapping("/api/members")
 @RequiredArgsConstructor
+@Tag(name = "회원 관리", description = "회원 정보 조회, 수정, 삭제 및 프로필 이미지 관리")
 public class MemberController {
 
     private final MemberService memberService;
 
+    @Operation(summary = "회원 정보 조회", description = "특정 회원의 프로필 정보를 조회합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "회원 정보 조회 성공"),
+            @ApiResponse(responseCode = "404", description = "회원을 찾을 수 없음")
+    })
     @GetMapping("/{memberId}")
-    public ResponseEntity<ApiResponse<GetMemberResponse>> getMemberProfile(
+    public ResponseEntity<ApiResponseFormat<GetMemberResponse>> getMemberProfile(
         @PathVariable final Long memberId
     ) {
         final GetMemberResponse response = memberService.getMemberProfile(memberId);
         return ResponseEntity.ok(
-                ApiResponse.success("회원 정보를 조회했습니다.", response)
+                ApiResponseFormat.success("회원 정보를 조회했습니다.", response)
         );
     }
 
+    @Operation(summary = "회원 정보 수정", description = "특정 회원의 프로필 정보를 수정합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "회원 정보 수정 성공"),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청 데이터"),
+            @ApiResponse(responseCode = "404", description = "회원을 찾을 수 없음")
+    })
     @PatchMapping("/{memberId}")
-    public ResponseEntity<ApiResponse<UpdateMemberResponse>> updateMember(
+    public ResponseEntity<ApiResponseFormat<UpdateMemberResponse>> updateMember(
             @PathVariable final Long memberId,
             @Valid @RequestBody final MemberRequest request
     ) {
         final UpdateMemberResponse response = memberService.updateMemberProfile(memberId, request);
         return ResponseEntity.ok(
-                ApiResponse.success("회원 정보를 수정했습니다.", response)
+                ApiResponseFormat.success("회원 정보를 수정했습니다.", response)
         );
     }
 
+    @Operation(summary = "내 정보 조회", description = "현재 로그인한 회원의 프로필 정보를 조회합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "내 정보 조회 성공"),
+            @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자")
+    })
     @GetMapping("/me")
-    public ResponseEntity<ApiResponse<GetMyProfileResponse>> getMyProfile(
+    public ResponseEntity<ApiResponseFormat<GetMyProfileResponse>> getMyProfile(
     ) {
         final Long memberId = getCurrentMemberId();
         final GetMyProfileResponse response = memberService.getMyProfile(memberId);
         return ResponseEntity.ok(
-                ApiResponse.success("내 정보를 조회했습니다", response)
+                ApiResponseFormat.success("내 정보를 조회했습니다", response)
         );
     }
 
+    @Operation(summary = "내 정보 수정", description = "현재 로그인한 회원의 프로필 정보를 수정합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "내 정보 수정 성공"),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청 데이터"),
+            @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자")
+    })
     @PatchMapping("/me")
-    public ResponseEntity<ApiResponse<UpdateMyProfileResponse>> updateMyProfile(
+    public ResponseEntity<ApiResponseFormat<UpdateMyProfileResponse>> updateMyProfile(
             @Valid @RequestBody final MemberRequest request
     ) {
         final Long memberId = getCurrentMemberId(); // 임시
         final UpdateMyProfileResponse response = memberService.updateMyProfile(memberId, request);
         return ResponseEntity.ok(
-                ApiResponse.success("내 정보를 수정했습니다.", response)
+                ApiResponseFormat.success("내 정보를 수정했습니다.", response)
         );
     }
 
+    @Operation(summary = "프로필 이미지 업로드", description = "회원의 프로필 이미지를 업로드합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "201", description = "프로필 이미지 업로드 성공"),
+            @ApiResponse(responseCode = "400", description = "잘못된 파일 형식 또는 크기"),
+            @ApiResponse(responseCode = "404", description = "회원을 찾을 수 없음")
+    })
+
     @PostMapping("/{memberId}/profile-images")
-    public ResponseEntity<ApiResponse<Void>> uploadProfileImage(
+    public ResponseEntity<ApiResponseFormat<Void>> uploadProfileImage(
             @PathVariable final Long memberId,
             @RequestParam("imageFile") final MultipartFile imageFile
     ) {
         memberService.uploadProfileImage(memberId, imageFile);
         return ResponseEntity.status(HttpStatus.CREATED)
-                .body(ApiResponse.success("프로필 이미지를 업로드했습니다."));
+                .body(ApiResponseFormat.success("프로필 이미지를 업로드했습니다."));
     }
 
+    @Operation(summary = "프로필 이미지 삭제", description = "회원의 프로필 이미지를 삭제합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "프로필 이미지 삭제 성공"),
+            @ApiResponse(responseCode = "404", description = "회원을 찾을 수 없음")
+    })
     @DeleteMapping("/{memberId}/profile-images")
-    public ResponseEntity<ApiResponse<Void>> deleteProfileImage(
+    public ResponseEntity<ApiResponseFormat<Void>> deleteProfileImage(
             @PathVariable final Long memberId
     ) {
         memberService.deleteProfileImage(memberId);
         return ResponseEntity.ok(
-                ApiResponse.success("프로필 이미지를 삭제했습니다.")
+                ApiResponseFormat.success("프로필 이미지를 삭제했습니다.")
         );
     }
 
+    @Operation(summary = "닉네임 존재 여부 확인", description = "특정 닉네임이 이미 사용 중인지 확인합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "닉네임이 존재함"),
+            @ApiResponse(responseCode = "404", description = "닉네임이 존재하지 않음")
+    })
     @RequestMapping(value = "/nicknames/{nickname}", method = RequestMethod.HEAD)
     public ResponseEntity<Void> checkNicknameExists(
             @PathVariable final String nickname
@@ -91,16 +135,26 @@ public class MemberController {
         return exists ? ResponseEntity.ok().build() : ResponseEntity.notFound().build();
     }
 
+    @Operation(summary = "닉네임 사용 가능 여부 조회", description = "특정 닉네임의 사용 가능 여부를 상세히 조회합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "닉네임 사용 가능 여부 조회 성공"),
+            @ApiResponse(responseCode = "400", description = "잘못된 닉네임 형식")
+    })
     @GetMapping("/nicknames/{nickname}/availability")
-    public ResponseEntity<ApiResponse<GetNicknameAvailabilityResponse>> getNicknameAvailability(
+    public ResponseEntity<ApiResponseFormat<GetNicknameAvailabilityResponse>> getNicknameAvailability(
             @PathVariable final String nickname
     ) {
         final GetNicknameAvailabilityResponse response = memberService.getNicknameAvailability(nickname);
         return ResponseEntity.ok(
-                ApiResponse.success("닉네임 사용 가능 여부를 조회했습니다.", response)
+                ApiResponseFormat.success("닉네임 사용 가능 여부를 조회했습니다.", response)
         );
     }
 
+    @Operation(summary = "이메일 존재 여부 확인", description = "특정 이메일이 이미 사용 중인지 확인합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "이메일이 존재함"),
+            @ApiResponse(responseCode = "404", description = "이메일이 존재하지 않음")
+    })
     @RequestMapping(value = "/emails/{email}", method = RequestMethod.HEAD)
     public ResponseEntity<Void> checkEmailExists(
             @PathVariable final String email
@@ -109,65 +163,91 @@ public class MemberController {
         return exists ? ResponseEntity.ok().build() : ResponseEntity.notFound().build();
     }
 
+    @Operation(summary = "이메일 사용 가능 여부 조회", description = "특정 이메일의 사용 가능 여부를 상세히 조회합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "이메일 사용 가능 여부 조회 성공"),
+            @ApiResponse(responseCode = "400", description = "잘못된 이메일 형식")
+    })
     @GetMapping("/emails/{email}/availability")
-    public ResponseEntity<ApiResponse<GetEmailAvailabilityResponse>> getEmailAvailability(
+    public ResponseEntity<ApiResponseFormat<GetEmailAvailabilityResponse>> getEmailAvailability(
             @PathVariable final String email
     ) {
         final GetEmailAvailabilityResponse response = memberService.getEmailAvailability(email);
         return ResponseEntity.ok(
-                ApiResponse.success("이메일 사용 가능 여부를 조회했습니다.", response)
+                ApiResponseFormat.success("이메일 사용 가능 여부를 조회했습니다.", response)
         );
     }
 
+    @Operation(summary = "회원 삭제", description = "관리자가 특정 회원을 삭제합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "회원 삭제 성공"),
+            @ApiResponse(responseCode = "400", description = "삭제 불가능한 상태 (활성 주문 등)"),
+            @ApiResponse(responseCode = "403", description = "권한 없음 (관리자 권한 필요)"),
+            @ApiResponse(responseCode = "404", description = "회원을 찾을 수 없음"),
+            @ApiResponse(responseCode = "500", description = "서버 오류")
+    })
     @DeleteMapping("/{memberId}")
-    @PreAuthorize("hasRole('ADMIN')") // 관리자만 접근 가능 (추후 구현)
-    public ResponseEntity<ApiResponse<Void>> deleteMember(
+    @PreAuthorize("hasRole('ADMIN')")
+    public ResponseEntity<ApiResponseFormat<Void>> deleteMember(
             @PathVariable final Long memberId) {
 
         try {
             memberService.deleteMember(memberId);
             return ResponseEntity.ok(
-                    ApiResponse.success("회원 탈퇴가 완료되었습니다.")
+                    ApiResponseFormat.success("회원 탈퇴가 완료되었습니다.")
             );
         } catch (IllegalStateException e) {
             // 탈퇴 불가능한 상태 (활성 주문 등)
             log.warn("Member deletion failed due to business rule: {}", e.getMessage());
             return ResponseEntity.badRequest()
-                    .body(ApiResponse.fail(e.getMessage()));
+                    .body(ApiResponseFormat.fail(e.getMessage()));
         } catch (Exception e) {
             // 기타 시스템 오류
             log.error("Unexpected error during member deletion for ID: {}", memberId, e);
             return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
-                    .body(ApiResponse.fail("탈퇴 처리 중 오류가 발생했습니다."));
+                    .body(ApiResponseFormat.fail("탈퇴 처리 중 오류가 발생했습니다."));
         }
     }
 
+    @Operation(summary = "회원 탈퇴", description = "현재 로그인한 회원이 스스로 탈퇴합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "회원 탈퇴 성공"),
+            @ApiResponse(responseCode = "400", description = "탈퇴 불가능한 상태 (활성 주문 등)"),
+            @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자"),
+            @ApiResponse(responseCode = "500", description = "서버 오류")
+    })
     @DeleteMapping("/me")
-    public ResponseEntity<ApiResponse<Void>> deleteMyAccount() {
+    public ResponseEntity<ApiResponseFormat<Void>> deleteMyAccount() {
         final Long memberId = getCurrentMemberId();
 
         try {
             memberService.deleteMember(memberId);
             return ResponseEntity.ok(
-                    ApiResponse.success("탈퇴가 완료되었습니다.")
+                    ApiResponseFormat.success("탈퇴가 완료되었습니다.")
             );
         } catch (IllegalStateException e) {
             log.warn("Member self-deletion failed for ID {}: {}", memberId, e.getMessage());
             return ResponseEntity.badRequest()
-                    .body(ApiResponse.fail(e.getMessage()));
+                    .body(ApiResponseFormat.fail(e.getMessage()));
         } catch (Exception e) {
             log.error("Unexpected error during self-deletion for member ID: {}", memberId, e);
             return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
-                    .body(ApiResponse.fail("탈퇴 처리 중 오류가 발생했습니다."));
+                    .body(ApiResponseFormat.fail("탈퇴 처리 중 오류가 발생했습니다."));
         }
     }
 
+    @Operation(summary = "탈퇴 미리보기", description = "회원 탈퇴 시 손실될 정보를 미리 확인합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "탈퇴 미리보기 조회 성공"),
+            @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자"),
+            @ApiResponse(responseCode = "404", description = "회원을 찾을 수 없음")
+    })
     @GetMapping("/me/withdrawal/priview")
-    public ResponseEntity<ApiResponse<GetWithdrawalPreviewResponse>> getWithdrawalPreview() {
+    public ResponseEntity<ApiResponseFormat<GetWithdrawalPreviewResponse>> getWithdrawalPreview() {
         final Long memberId = getCurrentMemberId();
         final GetWithdrawalPreviewResponse response = memberService.getWithdrawalPreview(memberId);
         return ResponseEntity.ok(
-                ApiResponse.success("탈퇴 시 손실 정보를 조회했습니다.", response)
+                ApiResponseFormat.success("탈퇴 시 손실 정보를 조회했습니다.", response)
         );
     }
 

--- a/src/main/java/com/ururulab/ururu/member/controller/MemberController.java
+++ b/src/main/java/com/ururulab/ururu/member/controller/MemberController.java
@@ -5,6 +5,7 @@ import com.ururulab.ururu.member.domain.dto.request.MemberRequest;
 import com.ururulab.ururu.member.domain.dto.response.GetMemberResponse;
 import com.ururulab.ururu.member.domain.dto.response.GetMyProfileResponse;
 import com.ururulab.ururu.member.domain.dto.response.UpdateMemberResponse;
+import com.ururulab.ururu.member.domain.dto.response.UpdateMyProfileResponse;
 import com.ururulab.ururu.member.service.MemberService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -33,7 +34,7 @@ public class MemberController {
             @PathVariable final Long memberId,
             @Valid @RequestBody final MemberRequest request
     ) {
-        final UpdateMemberResponse response = memberService.updateMember(memberId, request);
+        final UpdateMemberResponse response = memberService.updateMemberProfile(memberId, request);
         return ResponseEntity.ok(
                 ApiResponse.success("회원 정보를 수정했습니다.", response)
         );
@@ -46,6 +47,18 @@ public class MemberController {
         final GetMyProfileResponse response = memberService.getMyProfile(memberId);
         return ResponseEntity.ok(
                 ApiResponse.success("내 정보를 조회했습니다", response)
+        );
+    }
+
+    @PatchMapping("/me")
+    public ResponseEntity<ApiResponse<UpdateMyProfileResponse>> updateMyProfile(
+            @Valid @RequestBody final MemberRequest request
+    ) {
+        // TODO: JWT 토큰에서 memberId 추출
+        final Long memberId = 1L; // 임시
+        final UpdateMyProfileResponse response = memberService.updateMyProfile(memberId, request);
+        return ResponseEntity.ok(
+                ApiResponse.success("내 정보를 수정했습니다.", response)
         );
     }
 }

--- a/src/main/java/com/ururulab/ururu/member/controller/MemberController.java
+++ b/src/main/java/com/ururulab/ururu/member/controller/MemberController.java
@@ -221,7 +221,7 @@ public class MemberController {
             @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자"),
             @ApiResponse(responseCode = "404", description = "회원을 찾을 수 없음")
     })
-    @GetMapping("/me/withdrawal/priview")
+    @GetMapping("/me/withdrawal/preview")
     public ResponseEntity<ApiResponseFormat<GetWithdrawalPreviewResponse>> getWithdrawalPreview() {
         final Long memberId = getCurrentMemberId();
         final GetWithdrawalPreviewResponse response = memberService.getWithdrawalPreview(memberId);

--- a/src/main/java/com/ururulab/ururu/member/controller/MemberController.java
+++ b/src/main/java/com/ururulab/ururu/member/controller/MemberController.java
@@ -2,10 +2,7 @@ package com.ururulab.ururu.member.controller;
 
 import com.ururulab.ururu.global.common.dto.ApiResponse;
 import com.ururulab.ururu.member.domain.dto.request.MemberRequest;
-import com.ururulab.ururu.member.domain.dto.response.GetMemberResponse;
-import com.ururulab.ururu.member.domain.dto.response.GetMyProfileResponse;
-import com.ururulab.ururu.member.domain.dto.response.UpdateMemberResponse;
-import com.ururulab.ururu.member.domain.dto.response.UpdateMyProfileResponse;
+import com.ururulab.ururu.member.domain.dto.response.*;
 import com.ururulab.ururu.member.service.MemberService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -81,6 +78,24 @@ public class MemberController {
         memberService.deleteProfileImage(memberId);
         return ResponseEntity.ok(
                 ApiResponse.success("프로필 이미지를 삭제했습니다.")
+        );
+    }
+
+    @RequestMapping(value = "/nicknames/{nickname}", method = RequestMethod.HEAD)
+    public ResponseEntity<Void> checkNicknameExists(
+            @PathVariable final String nickname
+    ) {
+        final boolean exists = memberService.checkNicknameExists(nickname);
+        return exists ? ResponseEntity.ok().build() : ResponseEntity.notFound().build();
+    }
+
+    @GetMapping("/nicknames/{nickname}/availability")
+    public ResponseEntity<ApiResponse<GetNicknameAvailabilityResponse>> getNicknameAvailability(
+            @PathVariable final String nickname
+    ) {
+        final GetNicknameAvailabilityResponse response = memberService.getNicknameAvailability(nickname);
+        return ResponseEntity.ok(
+                ApiResponse.success("닉네임 사용 가능 여부를 조회했습니다.", response)
         );
     }
 }

--- a/src/main/java/com/ururulab/ururu/member/controller/MemberController.java
+++ b/src/main/java/com/ururulab/ururu/member/controller/MemberController.java
@@ -3,6 +3,7 @@ package com.ururulab.ururu.member.controller;
 import com.ururulab.ururu.global.common.dto.ApiResponse;
 import com.ururulab.ururu.member.domain.dto.request.MemberRequest;
 import com.ururulab.ururu.member.domain.dto.response.GetMemberResponse;
+import com.ururulab.ururu.member.domain.dto.response.GetMyProfileResponse;
 import com.ururulab.ururu.member.domain.dto.response.UpdateMemberResponse;
 import com.ururulab.ururu.member.service.MemberService;
 import jakarta.validation.Valid;
@@ -35,6 +36,16 @@ public class MemberController {
         final UpdateMemberResponse response = memberService.updateMember(memberId, request);
         return ResponseEntity.ok(
                 ApiResponse.success("회원 정보를 수정했습니다.", response)
+        );
+    }
+
+    @GetMapping("/me")
+    public ResponseEntity<ApiResponse<GetMyProfileResponse>> getMyProfile() {
+        // TODO: JWT 토큰에서 memberId 추출
+        final Long memberId = 1L;
+        final GetMyProfileResponse response = memberService.getMyProfile(memberId);
+        return ResponseEntity.ok(
+                ApiResponse.success("내 정보를 조회했습니다", response)
         );
     }
 }

--- a/src/main/java/com/ururulab/ururu/member/controller/MemberController.java
+++ b/src/main/java/com/ururulab/ururu/member/controller/MemberController.java
@@ -1,14 +1,14 @@
 package com.ururulab.ururu.member.controller;
 
 import com.ururulab.ururu.global.common.dto.ApiResponse;
+import com.ururulab.ururu.member.domain.dto.request.MemberRequest;
 import com.ururulab.ururu.member.domain.dto.response.GetMemberResponse;
+import com.ururulab.ururu.member.domain.dto.response.UpdateMemberResponse;
 import com.ururulab.ururu.member.service.MemberService;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/api/members")
@@ -24,6 +24,17 @@ public class MemberController {
         final GetMemberResponse response = memberService.getMemberProfile(memberId);
         return ResponseEntity.ok(
                 ApiResponse.success("회원 정보를 조회했습니다.", response)
+        );
+    }
+
+    @PatchMapping("/{memberId}")
+    public ResponseEntity<ApiResponse<UpdateMemberResponse>> updateMember(
+            @PathVariable final Long memberId,
+            @Valid @RequestBody final MemberRequest request
+    ) {
+        final UpdateMemberResponse response = memberService.updateMember(memberId, request);
+        return ResponseEntity.ok(
+                ApiResponse.success("회원 정보를 수정했습니다.", response)
         );
     }
 }

--- a/src/main/java/com/ururulab/ururu/member/controller/MemberController.java
+++ b/src/main/java/com/ururulab/ururu/member/controller/MemberController.java
@@ -98,4 +98,20 @@ public class MemberController {
                 ApiResponse.success("닉네임 사용 가능 여부를 조회했습니다.", response)
         );
     }
+
+    @RequestMapping(value = "/emails/{email}", method = RequestMethod.HEAD)
+    public ResponseEntity<Void> checkEmailExists(@PathVariable final String email) {
+        final boolean exists = memberService.checkEmailExists(email);
+        return exists ? ResponseEntity.ok().build() : ResponseEntity.notFound().build();
+    }
+
+    @GetMapping("/emails/{email}/availability")
+    public ResponseEntity<ApiResponse<GetEmailAvailabilityResponse>> getEmailAvailability(
+            @PathVariable final String email) {
+        final GetEmailAvailabilityResponse response = memberService.getEmailAvailability(email);
+        return ResponseEntity.ok(
+                ApiResponse.success("이메일 사용 가능 여부를 조회했습니다.", response)
+        );
+    }
+
 }

--- a/src/main/java/com/ururulab/ururu/member/domain/dto/response/GetEmailAvailabilityResponse.java
+++ b/src/main/java/com/ururulab/ururu/member/domain/dto/response/GetEmailAvailabilityResponse.java
@@ -1,0 +1,11 @@
+package com.ururulab.ururu.member.domain.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record GetEmailAvailabilityResponse(
+        @JsonProperty("is_available") boolean isAvailable
+) {
+    public static GetEmailAvailabilityResponse of(final boolean isAvailable) {
+        return new GetEmailAvailabilityResponse(isAvailable);
+    }
+}

--- a/src/main/java/com/ururulab/ururu/member/domain/dto/response/GetMemberResponse.java
+++ b/src/main/java/com/ururulab/ururu/member/domain/dto/response/GetMemberResponse.java
@@ -1,0 +1,41 @@
+package com.ururulab.ururu.member.domain.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.ururulab.ururu.member.domain.entity.Member;
+
+import java.time.LocalDate;
+import java.time.ZonedDateTime;
+
+public record GetMemberResponse(
+        Long id,
+        String email,
+        String nickname,
+        String gender,
+        LocalDate birth,
+        String phone,
+        @JsonProperty("profile_image") String profileImage,
+        @JsonProperty("social_provider") String socialProvider,
+        String role,
+        int point,
+        @JsonProperty("is_deleted") boolean isDeleted,
+        @JsonProperty("created_at") ZonedDateTime createdAt,
+        @JsonProperty("updated_at") ZonedDateTime updatedAt
+) {
+    public static GetMemberResponse from(final Member member) {
+        return new GetMemberResponse(
+                member.getId(),
+                member.getEmail(),
+                member.getNickname(),
+                member.getGender() != null ? member.getGender().name() : null,
+                member.getBirth(),
+                member.getPhone(),
+                member.getProfileImage(),
+                member.getSocialProvider().name(),
+                member.getRole().name(),
+                member.getPoint(),
+                member.isDeleted(),
+                member.getCreatedAt(),
+                member.getUpdatedAt()
+        );
+    }
+}

--- a/src/main/java/com/ururulab/ururu/member/domain/dto/response/GetMyProfileResponse.java
+++ b/src/main/java/com/ururulab/ururu/member/domain/dto/response/GetMyProfileResponse.java
@@ -1,0 +1,41 @@
+package com.ururulab.ururu.member.domain.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.ururulab.ururu.member.domain.entity.Member;
+
+import java.time.LocalDate;
+import java.time.ZonedDateTime;
+
+public record GetMyProfileResponse(
+        Long id,
+        String email,
+        String nickname,
+        String gender,
+        LocalDate birth,
+        String phone,
+        @JsonProperty("profile_image") String profileImage,
+        @JsonProperty("social_provider") String socialProvider,
+        String role,
+        int point,
+        @JsonProperty("is_deleted") boolean isDeleted,
+        @JsonProperty("created_at") ZonedDateTime createdAt,
+        @JsonProperty("updated_at") ZonedDateTime updatedAt
+) {
+    public static GetMyProfileResponse from(Member member) {
+        return new GetMyProfileResponse(
+                member.getId(),
+                member.getEmail(),
+                member.getNickname(),
+                member.getGender() != null ? member.getGender().name() : null,
+                member.getBirth(),
+                member.getPhone(),
+                member.getProfileImage(),
+                member.getSocialProvider().name(),
+                member.getRole().name(),
+                member.getPoint(),
+                member.isDeleted(),
+                member.getCreatedAt(),
+                member.getUpdatedAt()
+        );
+    }
+}

--- a/src/main/java/com/ururulab/ururu/member/domain/dto/response/GetNicknameAvailabilityResponse.java
+++ b/src/main/java/com/ururulab/ururu/member/domain/dto/response/GetNicknameAvailabilityResponse.java
@@ -1,0 +1,11 @@
+package com.ururulab.ururu.member.domain.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record GetNicknameAvailabilityResponse(
+        @JsonProperty("is_available") boolean isAvailable
+) {
+    public static GetNicknameAvailabilityResponse of(final boolean isAvailable){
+        return new GetNicknameAvailabilityResponse(isAvailable);
+    }
+}

--- a/src/main/java/com/ururulab/ururu/member/domain/dto/response/GetWithdrawalPreviewResponse.java
+++ b/src/main/java/com/ururulab/ururu/member/domain/dto/response/GetWithdrawalPreviewResponse.java
@@ -1,0 +1,73 @@
+package com.ururulab.ururu.member.domain.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record GetWithdrawalPreviewResponse(
+        @JsonProperty("member_info") MemberInfo memberInfo,
+        @JsonProperty("loss_info") LossInfo lossInfo
+) {
+    public static GetWithdrawalPreviewResponse of(
+            final MemberInfo memberInfo,
+            final LossInfo lossInfo
+    ) {
+        return new GetWithdrawalPreviewResponse(memberInfo, lossInfo);
+    }
+
+    public record MemberInfo(
+            String nickname,
+            String email,
+            @JsonProperty("join_date") String joinDate,
+            @JsonProperty("profile_image") String profileImage
+    ) {
+        public static MemberInfo of(
+                final String nickname,
+                final String email,
+                final String joinDate,
+                final String profileImage
+        ) {
+            return new MemberInfo(nickname, email, joinDate, profileImage);
+        }
+    }
+
+    public record LossInfo(
+            int points,
+            @JsonProperty("active_orders") int activeOrders,
+            @JsonProperty("review_count") int reviewCount,
+            @JsonProperty("beauty_profile_exists") boolean beautyProfileExists,
+            @JsonProperty("shipping_addresses_count") int shippingAddressesCount,
+            @JsonProperty("member_agreements_count") int memberAgreementsCount,
+            @JsonProperty("cart_items_count") int cartItemsCount,
+            @JsonProperty("point_transactions_count") int pointTransactionsCount
+    ) {
+        public static LossInfo of(
+                final int points,
+                final int activeOrders,
+                final int reviewCount,
+                final boolean beautyProfileExists,
+                final int shippingAddressesCount,
+                final int memberAgreementsCount,
+                final int cartItemsCount,
+                final int pointTransactionsCount
+        ) {
+            return new LossInfo(
+                    points,
+                    activeOrders,
+                    reviewCount,
+                    beautyProfileExists,
+                    shippingAddressesCount,
+                    memberAgreementsCount,
+                    cartItemsCount,
+                    pointTransactionsCount
+            );
+        }
+
+
+        public static LossInfo ofSimple(
+                final int points,
+                final int activeOrders,
+                final int reviewCount
+        ) {
+            return new LossInfo(points, activeOrders, reviewCount, false, 0, 0, 0, 0);
+        }
+    }
+}

--- a/src/main/java/com/ururulab/ururu/member/domain/dto/response/UpdateMemberResponse.java
+++ b/src/main/java/com/ururulab/ururu/member/domain/dto/response/UpdateMemberResponse.java
@@ -1,0 +1,31 @@
+package com.ururulab.ururu.member.domain.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.ururulab.ururu.member.domain.entity.Member;
+
+import java.time.LocalDate;
+import java.time.ZonedDateTime;
+
+public record UpdateMemberResponse(
+        Long id,
+        String email,
+        String nickname,
+        String gender,
+        LocalDate birth,
+        String phone,
+        @JsonProperty("profile_image") String profileImag,
+        @JsonProperty("updated_at") ZonedDateTime updatedAt
+) {
+    public static UpdateMemberResponse from (final Member member){
+        return new UpdateMemberResponse(
+                member.getId(),
+                member.getEmail(),
+                member.getNickname(),
+                member.getGender() != null ? member.getGender().name() : null,
+                member.getBirth(),
+                member.getPhone(),
+                member.getProfileImage(),
+                member.getUpdatedAt()
+        );
+    }
+}

--- a/src/main/java/com/ururulab/ururu/member/domain/dto/response/UpdateMyProfileResponse.java
+++ b/src/main/java/com/ururulab/ururu/member/domain/dto/response/UpdateMyProfileResponse.java
@@ -1,0 +1,31 @@
+package com.ururulab.ururu.member.domain.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.ururulab.ururu.member.domain.entity.Member;
+
+import java.time.LocalDate;
+import java.time.ZonedDateTime;
+
+public record UpdateMyProfileResponse(
+        Long id,
+        String email,
+        String nickname,
+        String gender,
+        LocalDate birth,
+        String phone,
+        @JsonProperty("profile_image") String profileImag,
+        @JsonProperty("updated_at") ZonedDateTime updatedAt
+) {
+    public static UpdateMyProfileResponse from(final Member member){
+        return new UpdateMyProfileResponse(
+                member.getId(),
+                member.getEmail(),
+                member.getNickname(),
+                member.getGender() != null ? member.getGender().name() : null,
+                member.getBirth(),
+                member.getPhone(),
+                member.getProfileImage(),
+                member.getUpdatedAt()
+        );
+    }
+}

--- a/src/main/java/com/ururulab/ururu/member/domain/entity/BeautyProfile.java
+++ b/src/main/java/com/ururulab/ururu/member/domain/entity/BeautyProfile.java
@@ -16,7 +16,7 @@ import java.util.List;
 
 @Entity
 @Getter
-@Table(name = "BeautyProfile")
+@Table(name = "beauty_profile")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class BeautyProfile extends BaseEntity {
     @Id

--- a/src/main/java/com/ururulab/ururu/member/domain/entity/Member.java
+++ b/src/main/java/com/ururulab/ururu/member/domain/entity/Member.java
@@ -16,7 +16,7 @@ import java.util.List;
 
 @Entity
 @Getter
-@Table(name = "Member")
+@Table(name = "members")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Member extends BaseEntity {
 

--- a/src/main/java/com/ururulab/ururu/member/domain/entity/Member.java
+++ b/src/main/java/com/ururulab/ururu/member/domain/entity/Member.java
@@ -114,4 +114,13 @@ public class Member extends BaseEntity {
     public void updatePhone(final String phone) {
         this.phone = phone;
     }
+
+    public void updateProfileImage(final String profileImage) {
+        this.profileImage = profileImage;
+    }
+
+    public void delete() {
+        this.isDeleted = true;
+    }
+
 }

--- a/src/main/java/com/ururulab/ururu/member/domain/entity/Member.java
+++ b/src/main/java/com/ururulab/ururu/member/domain/entity/Member.java
@@ -121,6 +121,7 @@ public class Member extends BaseEntity {
 
     public void delete() {
         this.isDeleted = true;
+        this.point = 0;
     }
 
 }

--- a/src/main/java/com/ururulab/ururu/member/domain/entity/MemberAgreement.java
+++ b/src/main/java/com/ururulab/ururu/member/domain/entity/MemberAgreement.java
@@ -11,7 +11,7 @@ import java.time.LocalDateTime;
 
 @Entity
 @Getter
-@Table(name = "MemberAgreement")
+@Table(name = "members_agreement")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class MemberAgreement extends BaseEntity {
 

--- a/src/main/java/com/ururulab/ururu/member/domain/entity/MemberPreference.java
+++ b/src/main/java/com/ururulab/ururu/member/domain/entity/MemberPreference.java
@@ -11,7 +11,7 @@ import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
-@Table(name = "MemberPreference")
+@Table(name = "members_preference")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class MemberPreference extends BaseEntity {
     @Id

--- a/src/main/java/com/ururulab/ururu/member/domain/entity/ShippingAddress.java
+++ b/src/main/java/com/ururulab/ururu/member/domain/entity/ShippingAddress.java
@@ -9,7 +9,7 @@ import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
-@Table(name = "ShippingAddress")
+@Table(name = "shipping_address")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class ShippingAddress extends BaseEntity {
     @Id

--- a/src/main/java/com/ururulab/ururu/member/domain/repository/BeautyProfileRepository.java
+++ b/src/main/java/com/ururulab/ururu/member/domain/repository/BeautyProfileRepository.java
@@ -16,5 +16,6 @@ public interface BeautyProfileRepository extends JpaRepository<BeautyProfile, Lo
 
     @Query("SELECT bp FROM BeautyProfile bp JOIN FETCH bp.member WHERE bp.member.id = :memberId")
     Optional<BeautyProfile> findByMemberIdWithMember(@Param("memberId") Long memberId);
-
+    boolean existsByMemberId(Long memberId);
+    void deleteByMemberId(Long memberId);
 }

--- a/src/main/java/com/ururulab/ururu/member/domain/repository/MemberAgreementRepository.java
+++ b/src/main/java/com/ururulab/ururu/member/domain/repository/MemberAgreementRepository.java
@@ -11,4 +11,6 @@ import java.util.List;
 public interface MemberAgreementRepository extends JpaRepository<MemberAgreement, Long> {
     List<MemberAgreement> findByMember(Member member);
     List<MemberAgreement> findByMemberId(Long memberId);
+    int countByMemberId(Long memberId);
+    void deleteByMemberId(Long memberId);
 }

--- a/src/main/java/com/ururulab/ururu/member/domain/repository/ShippingAddressRepository.java
+++ b/src/main/java/com/ururulab/ururu/member/domain/repository/ShippingAddressRepository.java
@@ -15,5 +15,6 @@ public interface ShippingAddressRepository extends JpaRepository<ShippingAddress
     Optional<ShippingAddress> findByMemberAndIsDefaultTrue(Member member);
     Optional<ShippingAddress> findByMemberIdAndIsDefaultTrue(Long memberId);
     Optional<ShippingAddress> findByIdAndMemberId(Long id, Long memberId);
-
+    int countByMemberId(Long memberId);
+    void deleteByMemberId(Long memberId);
 }

--- a/src/main/java/com/ururulab/ururu/member/service/MemberService.java
+++ b/src/main/java/com/ururulab/ururu/member/service/MemberService.java
@@ -4,6 +4,7 @@ import com.ururulab.ururu.auth.dto.info.SocialMemberInfo;
 import com.ururulab.ururu.global.common.entity.enumerated.Gender;
 import com.ururulab.ururu.member.domain.dto.request.MemberRequest;
 import com.ururulab.ururu.member.domain.dto.response.GetMemberResponse;
+import com.ururulab.ururu.member.domain.dto.response.GetMyProfileResponse;
 import com.ururulab.ururu.member.domain.dto.response.MemberResponse;
 import com.ururulab.ururu.member.domain.dto.response.UpdateMemberResponse;
 import com.ururulab.ururu.member.domain.entity.Member;
@@ -78,6 +79,11 @@ public class MemberService {
     public GetMemberResponse getMemberProfile(final Long memberId) {
         final Member member = findActiveMemberById(memberId);
         return GetMemberResponse.from(member);
+    }
+
+    public GetMyProfileResponse getMyProfile(final Long memberId) {
+        final Member member = findActiveMemberById(memberId);
+        return GetMyProfileResponse.from(member);
     }
 
     @Transactional

--- a/src/main/java/com/ururulab/ururu/member/service/MemberService.java
+++ b/src/main/java/com/ururulab/ururu/member/service/MemberService.java
@@ -12,6 +12,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
 
 @Slf4j
 @Service
@@ -93,6 +94,31 @@ public class MemberService {
     public UpdateMyProfileResponse updateMyProfile(final Long memberId, final MemberRequest request) {
         final Member updatedMember = updateProfile(memberId, request);
         return UpdateMyProfileResponse.from(updatedMember);
+    }
+
+    @Transactional
+    public void uploadProfileImage(final Long memberId, final MultipartFile imageFile) {
+        if (imageFile == null || imageFile.isEmpty()) {
+            throw new IllegalArgumentException("이미지 파일은 필수입니다.");
+        }
+
+        final Member member = findActiveMemberById(memberId);
+
+        // TODO: 이미지 업로드 서비스 구현 후 실제 업로드 처리
+        final String imageUrl = "https://example.com/profile/" + memberId + ".jpg"; // 임시
+
+        member.updateProfileImage(imageUrl);
+        memberRepository.save(member);
+
+        log.info("Profile image uploaded for member ID: {}", memberId);
+    }
+
+    @Transactional
+    public void deleteProfileImage(final Long memberId) {
+        final Member member = findActiveMemberById(memberId);
+
+        member.updateProfileImage(null);
+        memberRepository.save(member);
     }
 
     private Member updateProfile(final Long memberId, final MemberRequest request) {

--- a/src/main/java/com/ururulab/ururu/member/service/MemberService.java
+++ b/src/main/java/com/ururulab/ururu/member/service/MemberService.java
@@ -3,10 +3,7 @@ package com.ururulab.ururu.member.service;
 import com.ururulab.ururu.auth.dto.info.SocialMemberInfo;
 import com.ururulab.ururu.global.common.entity.enumerated.Gender;
 import com.ururulab.ururu.member.domain.dto.request.MemberRequest;
-import com.ururulab.ururu.member.domain.dto.response.GetMemberResponse;
-import com.ururulab.ururu.member.domain.dto.response.GetMyProfileResponse;
-import com.ururulab.ururu.member.domain.dto.response.MemberResponse;
-import com.ururulab.ururu.member.domain.dto.response.UpdateMemberResponse;
+import com.ururulab.ururu.member.domain.dto.response.*;
 import com.ururulab.ururu.member.domain.entity.Member;
 import com.ururulab.ururu.member.domain.entity.enumerated.Role;
 import com.ururulab.ururu.member.domain.repository.MemberRepository;
@@ -87,9 +84,15 @@ public class MemberService {
     }
 
     @Transactional
-    public UpdateMemberResponse updateMember(final Long memberId, final MemberRequest request) {
+    public UpdateMemberResponse updateMemberProfile(final Long memberId, final MemberRequest request) {
         final Member updatedMember = updateProfile(memberId, request);
         return UpdateMemberResponse.from(updatedMember);
+    }
+
+    @Transactional
+    public UpdateMyProfileResponse updateMyProfile(final Long memberId, final MemberRequest request) {
+        final Member updatedMember = updateProfile(memberId, request);
+        return UpdateMyProfileResponse.from(updatedMember);
     }
 
     private Member updateProfile(final Long memberId, final MemberRequest request) {

--- a/src/main/java/com/ururulab/ururu/member/service/MemberService.java
+++ b/src/main/java/com/ururulab/ururu/member/service/MemberService.java
@@ -64,16 +64,6 @@ public class MemberService {
         return savedMember;
     }
 
-    public MemberResponse checkEmail(final String email) {
-        final boolean isAvailable = memberRepository.isEmailAvailable(email);
-        return MemberResponse.ofAvailabilityCheck(isAvailable);
-    }
-
-    public MemberResponse checkNickname(final String nickname) {
-        final boolean isAvailable = memberRepository.isNicknameAvailable(nickname);
-        return MemberResponse.ofAvailabilityCheck(isAvailable);
-    }
-
     public GetMemberResponse getMemberProfile(final Long memberId) {
         final Member member = findActiveMemberById(memberId);
         return GetMemberResponse.from(member);
@@ -120,6 +110,25 @@ public class MemberService {
         member.updateProfileImage(null);
         memberRepository.save(member);
     }
+
+    public boolean checkNicknameExists(final String nickname) {
+        return memberRepository.existsByNickname(nickname);
+    }
+
+    public GetNicknameAvailabilityResponse getNicknameAvailability(final String nickname) {
+        final boolean isAvailable = memberRepository.isNicknameAvailable(nickname);
+        return GetNicknameAvailabilityResponse.of(isAvailable);
+    }
+
+
+    public MemberResponse checkEmail(final String email) {
+        final boolean isAvailable = memberRepository.isEmailAvailable(email);
+        return MemberResponse.ofAvailabilityCheck(isAvailable);
+    }
+
+
+
+
 
     private Member updateProfile(final Long memberId, final MemberRequest request) {
         final Member member = findActiveMemberById(memberId);

--- a/src/main/java/com/ururulab/ururu/member/service/MemberService.java
+++ b/src/main/java/com/ururulab/ururu/member/service/MemberService.java
@@ -5,6 +5,7 @@ import com.ururulab.ururu.global.common.entity.enumerated.Gender;
 import com.ururulab.ururu.member.domain.dto.request.MemberRequest;
 import com.ururulab.ururu.member.domain.dto.response.GetMemberResponse;
 import com.ururulab.ururu.member.domain.dto.response.MemberResponse;
+import com.ururulab.ururu.member.domain.dto.response.UpdateMemberResponse;
 import com.ururulab.ururu.member.domain.entity.Member;
 import com.ururulab.ururu.member.domain.entity.enumerated.Role;
 import com.ururulab.ururu.member.domain.repository.MemberRepository;
@@ -80,7 +81,12 @@ public class MemberService {
     }
 
     @Transactional
-    public MemberResponse updateProfile(final Long memberId, final MemberRequest request) {
+    public UpdateMemberResponse updateMember(final Long memberId, final MemberRequest request) {
+        final Member updatedMember = updateProfile(memberId, request);
+        return UpdateMemberResponse.from(updatedMember);
+    }
+
+    private Member updateProfile(final Long memberId, final MemberRequest request) {
         final Member member = findActiveMemberById(memberId);
 
         if (request.nickname() != null && !request.nickname().equals(member.getNickname())) {
@@ -94,7 +100,7 @@ public class MemberService {
         final Member updatedMember = memberRepository.save(member);
         log.info("Member profile updated for ID: {}", memberId);
 
-        return MemberResponse.of(updatedMember);
+        return updatedMember;
     }
 
 

--- a/src/main/java/com/ururulab/ururu/member/service/MemberService.java
+++ b/src/main/java/com/ururulab/ururu/member/service/MemberService.java
@@ -120,10 +120,13 @@ public class MemberService {
         return GetNicknameAvailabilityResponse.of(isAvailable);
     }
 
+    public boolean checkEmailExists(final String email) {
+        return memberRepository.existsByEmail(email);
+    }
 
-    public MemberResponse checkEmail(final String email) {
+    public GetEmailAvailabilityResponse getEmailAvailability(final String email) {
         final boolean isAvailable = memberRepository.isEmailAvailable(email);
-        return MemberResponse.ofAvailabilityCheck(isAvailable);
+        return GetEmailAvailabilityResponse.of(isAvailable);
     }
 
 

--- a/src/main/java/com/ururulab/ururu/member/service/MemberService.java
+++ b/src/main/java/com/ururulab/ururu/member/service/MemberService.java
@@ -3,6 +3,7 @@ package com.ururulab.ururu.member.service;
 import com.ururulab.ururu.auth.dto.info.SocialMemberInfo;
 import com.ururulab.ururu.global.common.entity.enumerated.Gender;
 import com.ururulab.ururu.member.domain.dto.request.MemberRequest;
+import com.ururulab.ururu.member.domain.dto.response.GetMemberResponse;
 import com.ururulab.ururu.member.domain.dto.response.MemberResponse;
 import com.ururulab.ururu.member.domain.entity.Member;
 import com.ururulab.ururu.member.domain.entity.enumerated.Role;
@@ -73,9 +74,9 @@ public class MemberService {
         return MemberResponse.ofAvailabilityCheck(isAvailable);
     }
 
-    public MemberResponse getMemberProfile(final Long memberId) {
+    public GetMemberResponse getMemberProfile(final Long memberId) {
         final Member member = findActiveMemberById(memberId);
-        return MemberResponse.of(member);
+        return GetMemberResponse.from(member);
     }
 
     @Transactional


### PR DESCRIPTION
## ⭐️ Issue Number
- #52

## 🚩 Summary
- Member 도메인의 MemberController 구현으로 클라이언트와 Service 계층 연결
- 회원 정보 조회/수정, 프로필 이미지 관리, 닉네임/이메일 중복 확인, 회원 탈퇴 관련 총 12개 API 엔드포인트 구현
- Swagger 애너테이션 추가로 API 문서화 완료
- Controller 계층의 책임 분리 원칙 준수 (검증 로직은 Service 계층에서 처리)

## 🛠️ Technical Concerns
- getCurrentMemberId() 메서드가 현재 하드코딩되어 있음 (JWT 토큰 파싱 로직 추후 구현 필요)
- 전역 예외 처리가 구현되지 않아 Service 계층에서 발생하는 예외에 대한 일관된 응답 형식 필요
- 프로필 이미지 업로드 시 파일 검증 로직(파일 크기, 형식 등)이 Service 계층에 구현되어야 함

## 🙂 To Reviewer
- Controller에서는 단순히 Service 호출 후 성공 응답만 반환하도록 구현했습니다.
- 비즈니스 로직 검증은 모두 Service 계층에서 처리하는 구조로 설계했습니다.
- Swagger 애너테이션으로 API 문서화를 완료했으니, 실제 API 스펙과 일치하는지 확인 부탁드립니다.
- REST API 규칙과 HTTP 메서드 사용이 적절한지 리뷰 부탁드립니다. (API 명세서 참고하여 작성했습니다.)

## 📋 To Do
BeautyProfile, MemberAgreement controller 구현