### PR TITLE
장바구니 CRUD API 구현

### DIFF
--- a/src/main/java/com/ururulab/ururu/groupBuy/domain/repository/GroupBuyOptionRepository.java
+++ b/src/main/java/com/ururulab/ururu/groupBuy/domain/repository/GroupBuyOptionRepository.java
@@ -1,0 +1,26 @@
+package com.ururulab.ururu.groupBuy.domain.repository;
+
+import com.ururulab.ururu.groupBuy.domain.entity.GroupBuyOption;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Optional;
+
+public interface GroupBuyOptionRepository extends JpaRepository<GroupBuyOption, Long> {
+
+    /**
+     * 공구 옵션 조회 (연관 엔티티 포함)
+     * Order 도메인 장바구니 기능에서 사용:
+     * - POST /cart/items: 공구 종료일 확인 (gb.endsAt)
+     * - 상품 정보 확인 (p.name)
+     * - 옵션 정보 확인 (po.name, po.image)
+     * - 가격 정보 확인 (gbo.salePrice)
+     */
+    @Query("SELECT gbo FROM GroupBuyOption gbo " +
+            "LEFT JOIN FETCH gbo.groupBuy gb " +
+            "LEFT JOIN FETCH gb.product p " +
+            "LEFT JOIN FETCH gbo.productOption po " +
+            "WHERE gbo.id = :optionId")
+    Optional<GroupBuyOption> findByIdWithDetails(@Param("optionId") Long optionId);
+}

--- a/src/main/java/com/ururulab/ururu/order/controller/CartController.java
+++ b/src/main/java/com/ururulab/ururu/order/controller/CartController.java
@@ -1,0 +1,115 @@
+package com.ururulab.ururu.order.controller;
+
+import com.ururulab.ururu.global.common.dto.ApiResponseFormat;
+import com.ururulab.ururu.order.domain.dto.request.CartItemAddRequest;
+import com.ururulab.ururu.order.domain.dto.request.CartItemQuantityChangeRequest;
+import com.ururulab.ururu.order.domain.dto.response.CartItemAddResponse;
+import com.ururulab.ururu.order.domain.dto.response.CartResponse;
+import com.ururulab.ururu.order.domain.dto.response.CartItemQuantityChangeResponse;
+import com.ururulab.ururu.order.service.CartService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@Slf4j
+@RestController
+@RequestMapping("/api/cart")
+@RequiredArgsConstructor
+@Tag(name = "장바구니", description = "장바구니 관리 API")
+public class CartController {
+
+    private final CartService cartService;
+
+    @Operation(summary = "장바구니 아이템 추가", description = "공구 옵션을 장바구니에 추가합니다. 이미 존재하는 옵션인 경우 수량이 증가됩니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "201", description = "장바구니 추가 성공"),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청 데이터"),
+            @ApiResponse(responseCode = "401", description = "인증 실패"),
+            @ApiResponse(responseCode = "404", description = "존재하지 않는 공구 옵션"),
+            @ApiResponse(responseCode = "409", description = "종료된 공구")
+    })
+    @PostMapping("/items")
+    public ResponseEntity<ApiResponseFormat<CartItemAddResponse>> addCartItem(
+            @AuthenticationPrincipal Long memberId,
+            @Valid @RequestBody CartItemAddRequest request
+    ) {
+        log.debug("장바구니 아이템 추가 요청 - 회원ID: {}, 요청: {}", memberId, request);
+
+        CartItemAddResponse response = cartService.addCartItem(memberId, request);
+
+        return ResponseEntity
+                .status(HttpStatus.CREATED)
+                .body(ApiResponseFormat.success("장바구니에 추가되었습니다", response));
+    }
+
+    @Operation(summary = "장바구니 조회", description = "회원의 장바구니를 조회합니다. 만료된 공구는 자동으로 제외됩니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "장바구니 조회 성공"),
+            @ApiResponse(responseCode = "401", description = "인증 실패")
+    })
+    @GetMapping
+    public ResponseEntity<ApiResponseFormat<CartResponse>> getCart(
+            @AuthenticationPrincipal Long memberId
+    ) {
+        log.debug("장바구니 조회 요청 - 회원ID: {}", memberId);
+
+        CartResponse response = cartService.getCart(memberId);
+
+        return ResponseEntity.ok(
+                ApiResponseFormat.success("장바구니 조회 성공", response)
+        );
+    }
+
+    @Operation(summary = "장바구니 아이템 수량 변경", description = "장바구니 아이템의 수량을 변경합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "수량 변경 성공"),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청 데이터"),
+            @ApiResponse(responseCode = "401", description = "인증 실패"),
+            @ApiResponse(responseCode = "404", description = "존재하지 않는 장바구니 아이템"),
+            @ApiResponse(responseCode = "403", description = "다른 사용자의 장바구니 아이템")
+    })
+    @PutMapping("/items/{cartItemId}")
+    public ResponseEntity<ApiResponseFormat<CartItemQuantityChangeResponse>> updateCartItemQuantity(
+            @AuthenticationPrincipal Long memberId,
+            @PathVariable Long cartItemId,
+            @Valid @RequestBody CartItemQuantityChangeRequest request
+    ) {
+        log.debug("장바구니 아이템 수량 변경 요청 - 회원ID: {}, 아이템ID: {}, 요청: {}",
+                memberId, cartItemId, request);
+
+        CartItemQuantityChangeResponse response = cartService.updateCartItemQuantity(memberId, cartItemId, request);
+
+        return ResponseEntity.ok(
+                ApiResponseFormat.success("수량이 변경되었습니다", response)
+        );
+    }
+
+    @Operation(summary = "장바구니 아이템 삭제", description = "장바구니에서 특정 아이템을 삭제합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "삭제 성공"),
+            @ApiResponse(responseCode = "401", description = "인증 실패"),
+            @ApiResponse(responseCode = "404", description = "존재하지 않는 장바구니 아이템"),
+            @ApiResponse(responseCode = "403", description = "다른 사용자의 장바구니 아이템")
+    })
+    @DeleteMapping("/items/{cartItemId}")
+    public ResponseEntity<ApiResponseFormat<Void>> removeCartItem(
+            @AuthenticationPrincipal Long memberId,
+            @PathVariable Long cartItemId
+    ) {
+        log.debug("장바구니 아이템 삭제 요청 - 회원ID: {}, 아이템ID: {}", memberId, cartItemId);
+
+        cartService.removeCartItem(memberId, cartItemId);
+
+        return ResponseEntity.ok(
+                ApiResponseFormat.success("장바구니에서 삭제되었습니다")
+        );
+    }
+}

--- a/src/main/java/com/ururulab/ururu/order/domain/dto/request/CartItemAddRequest.java
+++ b/src/main/java/com/ururulab/ururu/order/domain/dto/request/CartItemAddRequest.java
@@ -1,0 +1,18 @@
+package com.ururulab.ururu.order.domain.dto.request;
+
+import com.ururulab.ururu.order.domain.dto.validation.ValidationConstants;
+import com.ururulab.ururu.order.domain.dto.validation.ValidationMessages;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+
+public record CartItemAddRequest(
+        @NotNull(message = ValidationMessages.GROUPBUY_OPTION_ID_REQUIRED)
+        Long groupbuyOptionId,
+
+        @NotNull(message = ValidationMessages.QUANTITY_REQUIRED)
+        @Min(value = ValidationConstants.QUANTITY_MIN, message = ValidationMessages.QUANTITY_MIN)
+        @Max(value = ValidationConstants.QUANTITY_MAX, message = ValidationMessages.QUANTITY_MAX)
+        Integer quantity
+) {
+}

--- a/src/main/java/com/ururulab/ururu/order/domain/dto/request/CartItemQuantityChangeRequest.java
+++ b/src/main/java/com/ururulab/ururu/order/domain/dto/request/CartItemQuantityChangeRequest.java
@@ -1,0 +1,15 @@
+package com.ururulab.ururu.order.domain.dto.request;
+
+import com.ururulab.ururu.order.domain.dto.validation.ValidationConstants;
+import com.ururulab.ururu.order.domain.dto.validation.ValidationMessages;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+
+public record CartItemQuantityChangeRequest(
+        @NotNull(message = ValidationMessages.QUANTITY_CHANGE_REQUIRED)
+        @Min(value = ValidationConstants.QUANTITY_CHANGE_MIN, message = ValidationMessages.QUANTITY_CHANGE_MIN)
+        @Max(value = ValidationConstants.QUANTITY_CHANGE_MAX, message = ValidationMessages.QUANTITY_CHANGE_MAX)
+        Integer quantityChange
+) {
+}

--- a/src/main/java/com/ururulab/ururu/order/domain/dto/response/CartItemAddResponse.java
+++ b/src/main/java/com/ururulab/ururu/order/domain/dto/response/CartItemAddResponse.java
@@ -1,0 +1,11 @@
+package com.ururulab.ururu.order.domain.dto.response;
+
+/**
+ * 장바구니 아이템 추가 응답 DTO
+ * POST /cart/items 응답
+ */
+public record CartItemAddResponse(
+        Long cartItemId,
+        Integer quantity
+) {
+}

--- a/src/main/java/com/ururulab/ururu/order/domain/dto/response/CartItemQuantityChangeResponse.java
+++ b/src/main/java/com/ururulab/ururu/order/domain/dto/response/CartItemQuantityChangeResponse.java
@@ -1,0 +1,11 @@
+package com.ururulab.ururu.order.domain.dto.response;
+
+/**
+ * 장바구니 아이템 수량 변경 응답 DTO
+ * PUT /cart/items/{cartItemId} 응답
+ */
+public record CartItemQuantityChangeResponse(
+        Long cartItemId,
+        Integer quantity
+) {
+}

--- a/src/main/java/com/ururulab/ururu/order/domain/dto/response/CartItemResponse.java
+++ b/src/main/java/com/ururulab/ururu/order/domain/dto/response/CartItemResponse.java
@@ -1,0 +1,19 @@
+package com.ururulab.ururu.order.domain.dto.response;
+
+import java.time.ZonedDateTime;
+
+/**
+ * 장바구니 아이템 정보 DTO
+ * GET /cart 응답의 cartItems 배열 요소
+ */
+public record CartItemResponse(
+        Long cartItemId,
+        Long groupbuyOptionId,
+        Integer quantity,
+        String productName,
+        String optionName,
+        String optionImage,
+        Integer price,
+        ZonedDateTime endsAt
+) {
+}

--- a/src/main/java/com/ururulab/ururu/order/domain/dto/response/CartResponse.java
+++ b/src/main/java/com/ururulab/ururu/order/domain/dto/response/CartResponse.java
@@ -1,0 +1,12 @@
+package com.ururulab.ururu.order.domain.dto.response;
+
+import java.util.List;
+
+/**
+ * 장바구니 조회 응답 DTO
+ * GET /cart 응답
+ */
+public record CartResponse(
+        List<CartItemResponse> cartItems
+) {
+}

--- a/src/main/java/com/ururulab/ururu/order/domain/dto/validation/ValidationConstants.java
+++ b/src/main/java/com/ururulab/ururu/order/domain/dto/validation/ValidationConstants.java
@@ -1,0 +1,12 @@
+package com.ururulab.ururu.order.domain.dto.validation;
+
+import lombok.experimental.UtilityClass;
+
+@UtilityClass
+public class ValidationConstants {
+    public static final int QUANTITY_MIN = 1;
+    public static final int QUANTITY_MAX = 999;
+
+    public static final int QUANTITY_CHANGE_MIN = -999;
+    public static final int QUANTITY_CHANGE_MAX = 999;
+}

--- a/src/main/java/com/ururulab/ururu/order/domain/dto/validation/ValidationMessages.java
+++ b/src/main/java/com/ururulab/ururu/order/domain/dto/validation/ValidationMessages.java
@@ -1,0 +1,18 @@
+package com.ururulab.ururu.order.domain.dto.validation;
+
+import lombok.experimental.UtilityClass;
+
+@UtilityClass
+public class ValidationMessages {
+
+    // 장바구니 추가 관련
+    public static final String GROUPBUY_OPTION_ID_REQUIRED = "공구 옵션 ID는 필수입니다.";
+    public static final String QUANTITY_REQUIRED = "수량은 필수입니다.";
+    public static final String QUANTITY_MIN = "수량은 최소 1개입니다.";
+    public static final String QUANTITY_MAX = "수량은 최대 999개까지 가능합니다.";
+
+    // 수량 변경 관련
+    public static final String QUANTITY_CHANGE_REQUIRED = "수량 변화량은 필수입니다.";
+    public static final String QUANTITY_CHANGE_MIN = "수량 변화량은 최소 -999개입니다.";
+    public static final String QUANTITY_CHANGE_MAX = "수량 변화량은 최대 +999개입니다.";
+}

--- a/src/main/java/com/ururulab/ururu/order/domain/entity/Cart.java
+++ b/src/main/java/com/ururulab/ururu/order/domain/entity/Cart.java
@@ -13,7 +13,7 @@ import java.util.List;
 
 @Entity
 @Getter
-@Table(name = "cart")
+@Table(name = "carts")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Cart extends BaseEntity {
 

--- a/src/main/java/com/ururulab/ururu/order/domain/entity/CartItem.java
+++ b/src/main/java/com/ururulab/ururu/order/domain/entity/CartItem.java
@@ -10,7 +10,7 @@ import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
-@Table(name = "cart_item")
+@Table(name = "cart_items")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class CartItem extends BaseEntity {
 

--- a/src/main/java/com/ururulab/ururu/order/domain/entity/Order.java
+++ b/src/main/java/com/ururulab/ururu/order/domain/entity/Order.java
@@ -16,7 +16,7 @@ import java.util.UUID;
 
 @Entity
 @Getter
-@Table(name = "order")
+@Table(name = "orders")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Order extends BaseEntity {
 

--- a/src/main/java/com/ururulab/ururu/order/domain/entity/OrderHistory.java
+++ b/src/main/java/com/ururulab/ururu/order/domain/entity/OrderHistory.java
@@ -10,7 +10,7 @@ import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
-@Table(name = "order_history")
+@Table(name = "order_histories")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class OrderHistory extends BaseEntity {
 

--- a/src/main/java/com/ururulab/ururu/order/domain/entity/OrderItem.java
+++ b/src/main/java/com/ururulab/ururu/order/domain/entity/OrderItem.java
@@ -10,7 +10,7 @@ import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
-@Table(name = "order_item")
+@Table(name = "order_items")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class OrderItem extends BaseEntity {
 

--- a/src/main/java/com/ururulab/ururu/order/domain/repository/CartItemRepository.java
+++ b/src/main/java/com/ururulab/ururu/order/domain/repository/CartItemRepository.java
@@ -1,0 +1,29 @@
+package com.ururulab.ururu.order.domain.repository;
+
+import com.ururulab.ururu.groupBuy.domain.entity.GroupBuyOption;
+import com.ururulab.ururu.order.domain.entity.Cart;
+import com.ururulab.ururu.order.domain.entity.CartItem;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Optional;
+
+public interface CartItemRepository extends JpaRepository<CartItem, Long> {
+    Optional<CartItem> findByCartAndGroupBuyOption(Cart cart, GroupBuyOption groupBuyOption);
+
+    /**
+     * 장바구니 아이템 조회 (연관 엔티티 페치조인)
+     * PUT /cart/items/{cartItemId}, DELETE /cart/items/{cartItemId}에서 사용
+     */
+    @Query("SELECT ci FROM CartItem ci " +
+            "LEFT JOIN FETCH ci.groupBuyOption gbo " +
+            "LEFT JOIN FETCH gbo.groupBuy gb " +
+            "LEFT JOIN FETCH gb.product p " +
+            "LEFT JOIN FETCH gbo.productOption po " +
+            "WHERE ci.id = :cartItemId AND ci.cart.member.id = :memberId")
+    Optional<CartItem> findByIdAndMemberIdWithDetails(
+            @Param("cartItemId") Long cartItemId,
+            @Param("memberId") Long memberId
+    );
+}

--- a/src/main/java/com/ururulab/ururu/order/domain/repository/CartRepository.java
+++ b/src/main/java/com/ururulab/ururu/order/domain/repository/CartRepository.java
@@ -1,0 +1,27 @@
+package com.ururulab.ururu.order.domain.repository;
+
+import com.ururulab.ururu.member.domain.entity.Member;
+import com.ururulab.ururu.order.domain.entity.Cart;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Optional;
+
+public interface CartRepository extends JpaRepository<Cart, Long> {
+    Optional<Cart> findByMemberId(Long memberId);
+
+    /**
+     * 회원의 장바구니 조회 (연관 엔티티 페치조인)
+     * GET /cart API에서 사용 - N+1 문제 방지
+     * 조회 시점에서 만료된 공구 필터링 예정
+     */
+    @Query("SELECT c FROM Cart c " +
+            "LEFT JOIN FETCH c.cartItems ci " +
+            "LEFT JOIN FETCH ci.groupBuyOption gbo " +
+            "LEFT JOIN FETCH gbo.groupBuy gb " +
+            "LEFT JOIN FETCH gb.product p " +
+            "LEFT JOIN FETCH gbo.productOption po " +
+            "WHERE c.member.id = :memberId")
+    Optional<Cart> findByMemberIdWithCartItems(@Param("memberId") Long memberId);
+}

--- a/src/main/java/com/ururulab/ururu/order/domain/repository/OrderItemRepository.java
+++ b/src/main/java/com/ururulab/ururu/order/domain/repository/OrderItemRepository.java
@@ -1,0 +1,23 @@
+package com.ururulab.ururu.order.domain.repository;
+
+import com.ururulab.ururu.order.domain.entity.OrderItem;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface OrderItemRepository extends JpaRepository<OrderItem, Long> {
+
+    /**
+     * 특정 회원의 특정 공구 옵션 장바구니 수량 조회 (개인 구매 제한 검증용)
+     * 장바구니 추가/수정 시 사용 - 기존 장바구니 수량 확인
+     */
+    @Query("SELECT COALESCE(SUM(oi.quantity), 0) FROM OrderItem oi " +
+            "JOIN oi.order o " +
+            "WHERE o.member.id = :memberId " +
+            "AND oi.groupBuyOption.id = :groupBuyOptionId " +
+            "AND o.status = 'ORDERED'")
+    Integer getTotalOrderedQuantityByMemberAndOption(
+            @Param("memberId") Long memberId,
+            @Param("groupBuyOptionId") Long groupBuyOptionId
+    );
+}

--- a/src/main/java/com/ururulab/ururu/order/service/CartService.java
+++ b/src/main/java/com/ururulab/ururu/order/service/CartService.java
@@ -1,0 +1,201 @@
+package com.ururulab.ururu.order.service;
+
+import com.ururulab.ururu.groupBuy.domain.entity.GroupBuyOption;
+import com.ururulab.ururu.groupBuy.domain.repository.GroupBuyOptionRepository;
+import com.ururulab.ururu.member.domain.entity.Member;
+import com.ururulab.ururu.member.domain.repository.MemberRepository;
+import com.ururulab.ururu.order.domain.dto.request.CartItemAddRequest;
+import com.ururulab.ururu.order.domain.dto.request.CartItemQuantityChangeRequest;
+import com.ururulab.ururu.order.domain.dto.response.CartItemAddResponse;
+import com.ururulab.ururu.order.domain.dto.response.CartItemQuantityChangeResponse;
+import com.ururulab.ururu.order.domain.dto.response.CartItemResponse;
+import com.ururulab.ururu.order.domain.dto.response.CartResponse;
+import com.ururulab.ururu.order.domain.entity.Cart;
+import com.ururulab.ururu.order.domain.entity.CartItem;
+import com.ururulab.ururu.order.domain.repository.CartRepository;
+import com.ururulab.ururu.order.domain.repository.CartItemRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.*;
+import java.util.List;
+import java.util.Optional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class CartService {
+
+    private final CartRepository cartRepository;
+    private final CartItemRepository cartItemRepository;
+    private final GroupBuyOptionRepository groupBuyOptionRepository;
+    private final MemberRepository memberRepository;
+
+    /**
+     * 장바구니에 아이템을 추가
+     *
+     * @param memberId 회원 ID
+     * @param request 장바구니 아이템 추가 요청 DTO
+     */
+    @Transactional
+    public CartItemAddResponse addCartItem(Long memberId, CartItemAddRequest request) {
+        log.debug("장바구니 아이템 추가 - 회원ID: {}, 옵션ID: {}, 수량: {}",
+                memberId, request.groupbuyOptionId(), request.quantity());
+
+        GroupBuyOption groupBuyOption = groupBuyOptionRepository
+                .findByIdWithDetails(request.groupbuyOptionId())
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 공구 옵션입니다."));
+
+        ZonedDateTime endsAt = toZonedDateTime(groupBuyOption.getGroupBuy().getEndsAt());
+        if (endsAt.isBefore(ZonedDateTime.now(ZoneId.of("Asia/Seoul")))) {
+            throw new IllegalStateException("종료된 공구입니다.");
+        }
+        Cart cart = getOrCreateCart(memberId);
+
+        Optional<CartItem> existingItem = cartItemRepository
+                .findByCartAndGroupBuyOption(cart, groupBuyOption);
+
+        CartItem cartItem;
+        if (existingItem.isPresent()) {
+            cartItem = existingItem.get();
+            cartItem.increaseQuantity(request.quantity());
+            log.debug("기존 장바구니 아이템 수량 증가 - 아이템ID: {}, 새 수량: {}",
+                    cartItem.getId(), cartItem.getQuantity());
+        } else {
+            cartItem = CartItem.create(groupBuyOption, request.quantity());
+            cart.addItem(cartItem);
+            cartItemRepository.save(cartItem);
+            log.debug("새 장바구니 아이템 추가 - 옵션ID: {}, 수량: {}",
+                    groupBuyOption.getId(), request.quantity());
+        }
+
+        return new CartItemAddResponse(
+                cartItem.getId(),
+                cartItem.getQuantity()
+        );
+    }
+
+    /**
+     * 장바구니 조회
+     * @param memberId 회원 ID
+     */
+    @Transactional(readOnly = true)
+    public CartResponse getCart(Long memberId) {
+        log.debug("장바구니 조회 - 회원ID: {}", memberId);
+
+        Optional<Cart> cartOpt = cartRepository.findByMemberIdWithCartItems(memberId);
+
+        if (cartOpt.isEmpty() || cartOpt.get().isEmpty()) {
+            return new CartResponse(List.of());
+        }
+
+        Cart cart = cartOpt.get();
+
+        List<CartItemResponse> cartItemResponses = cart.getCartItems().stream()
+                .filter(this::isNotExpired)
+                .map(this::toCartItemResponse)
+                .toList();
+
+        return new CartResponse(cartItemResponses);
+    }
+
+    /**
+     * 장바구니 아이템 수량 변경
+     * @param memberId 회원 ID
+     * @param cartItemId 변경 대상 장바구니 아이템 ID
+     * @param request 수량 변경 요청 DTO
+     */
+    @Transactional
+    public CartItemQuantityChangeResponse updateCartItemQuantity(Long memberId, Long cartItemId, CartItemQuantityChangeRequest request) {
+        log.debug("장바구니 아이템 수량 변경 - 회원ID: {}, 아이템ID: {}, 변화량: {}",
+                memberId, cartItemId, request.quantityChange());
+
+        CartItem cartItem = cartItemRepository
+                .findByIdAndMemberIdWithDetails(cartItemId, memberId)
+                .orElseThrow(() -> new IllegalArgumentException("장바구니 아이템을 찾을 수 없습니다."));
+
+        if (request.quantityChange() > 0) {
+            cartItem.increaseQuantity(request.quantityChange());
+        } else {
+            cartItem.decreaseQuantity(Math.abs(request.quantityChange()));
+        }
+
+        log.debug("장바구니 아이템 수량 변경 완료 - 아이템ID: {}, 새 수량: {}", cartItemId, cartItem.getQuantity());
+        return new CartItemQuantityChangeResponse(cartItemId, cartItem.getQuantity());
+    }
+
+    /**
+     * 장바구니 아이템 삭제
+     * @param memberId 회원 ID
+     * @param cartItemId 삭제할 장바구니 아이템 ID
+     */
+    @Transactional
+    public void removeCartItem(Long memberId, Long cartItemId) {
+        log.debug("장바구니 아이템 삭제 - 회원ID: {}, 아이템ID: {}", memberId, cartItemId);
+
+        CartItem cartItem = cartItemRepository
+                .findByIdAndMemberIdWithDetails(cartItemId, memberId)
+                .orElseThrow(() -> new IllegalArgumentException("장바구니 아이템을 찾을 수 없습니다."));
+
+        Cart cart = cartItem.getCart();
+        cart.removeItem(cartItem);
+        cartItemRepository.delete(cartItem);
+
+        log.debug("장바구니 아이템 삭제 완료 - 아이템ID: {}", cartItemId);
+    }
+
+    private Cart getOrCreateCart(Long memberId) {
+        return cartRepository.findByMemberId(memberId)
+                .orElseGet(() -> {
+                    Member member = memberRepository.findById(memberId)
+                            .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 회원입니다."));
+                    Cart newCart = Cart.create(member);
+                    return cartRepository.save(newCart);
+                });
+    }
+
+    private boolean isNotExpired(CartItem cartItem) {
+        ZonedDateTime endsAt = toZonedDateTime(cartItem.getGroupBuyOption().getGroupBuy().getEndsAt());
+        ZonedDateTime now = ZonedDateTime.now(ZoneId.of("Asia/Seoul"));
+        return endsAt.isAfter(now);
+    }
+
+    private CartItemResponse toCartItemResponse(CartItem cartItem) {
+        GroupBuyOption option = cartItem.getGroupBuyOption();
+
+        return new CartItemResponse(
+                cartItem.getId(),
+                option.getId(),
+                cartItem.getQuantity(),
+                option.getGroupBuy().getProduct().getName(),
+                option.getProductOption().getName(),
+                option.getProductOption().getImageUrl(),
+                option.getSalePrice(),
+                toZonedDateTime(option.getGroupBuy().getEndsAt())
+        );
+    }
+
+    /**
+     * LocalDateTime 등 다양한 시간 객체를 ZonedDateTime으로 변환
+     * LocalDateTime이면 Asia/Seoul 기준으로, Zoned/OffsetDateTime이면 그대로
+     * 시간 객체 타입이 ZonedDateTime으로 확정 시 메서드 삭제 예정
+     */
+    private ZonedDateTime toZonedDateTime(Object time) {
+        ZoneId zoneId = ZoneId.of("Asia/Seoul");
+
+        if (time instanceof ZonedDateTime zdt) {
+            return zdt;
+        } else if (time instanceof OffsetDateTime odt) {
+            return odt.toZonedDateTime();
+        } else if (time instanceof LocalDateTime ldt) {
+            return ldt.atZone(zoneId);
+        } else if (time instanceof Instant instant) {
+            return instant.atZone(zoneId);
+        } else {
+            throw new IllegalArgumentException("지원하지 않는 시간 타입입니다: " +
+                    (time != null ? time.getClass().getName() : "null"));
+        }
+    }
+}


### PR DESCRIPTION
## ⭐️ Issue Number
- #41 

## 🚩 Summary
- 장바구니 CRUD API 4개 구현 (담기, 조회, 수정, 삭제)
- Controller, Service, Repository 전체 레이어 구현 완료
- 요청/응답 DTO 클래스 설계 및 구현
- 개인별 구매 수량 제한 검증 구현
- Swagger API 문서화

## 🛠️ Technical Concerns
**상황**: 사용자가 장바구니에 상품을 추가하려고 할 때, 개인별 구매 수량 제한을 검증해야 함

**검증 순서**:
- 공구 정보 조회: 장바구니에 추가하려는 공구 옵션을 조회
- 조인해서 올라가기: GroupBuyOption → GroupBuy로 가서 제한 수량 확인
- 이 공구의 "1인당 최대 구매 가능 수량"이 몇 개인지 확인
- 다시 내려와서: 이제 실제 구매 내역을 확인하러 감
- 구매 내역 조회: Order 테이블에서 이 사용자가 이 옵션을 얼마나 이미 주문했는지 확인
- 장바구니 현황 확인: 현재 장바구니에 이 옵션이 몇 개 들어있는지 확인
- 총합 계산: (기존 주문량) + (장바구니 현재량) + (지금 추가하려는 량) = 총량
- 제한 검증: 총량이 최대 구매 가능 수량을 넘으면 에러, 안 넘으면 통과

**문제와 보완 사항**:
-  조인이 너무 많아 성능과 복잡도 이슈가 있음 → 이를 개선하기 위해 CQRS 패턴 도입을 검토 중
- CQRS 패턴을 도입하면:
  - 읽기 전용 Projection을 따로 구축해 검증 로직을 단순화
  - UserPurchaseSummary 같은 뷰/서머리 테이블을 통해 쿼리 복잡도를 줄임
  - MongoDB 등 NoSQL을 활용해 구매 내역과 장바구니 상태를 하나의 문서로 통합 저장하고, 이를 통해 조회 성능을 최적화하는 설계도 병행 검토 중
  
## 🙂 To Reviewer
- DTO validation 정책 (수량 범위, 필수값 등)이 비즈니스 요구사항에 맞는지 확인 요청
- validatePurchaseLimit 비즈니스 로직 검증이 올바른지 확인 요청
- 예외 처리 로직 및 에러 메시지가 적절한지 검토 요청
- 현재 조인 구조 및 쿼리 성능이 적절한지 확인 요청

## 📋 To Do
-  테스트 코드 작성
- 공동 구매/주문 API 구현 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 장바구니 API가 추가되어 상품 옵션을 장바구니에 담기, 장바구니 조회, 수량 변경, 삭제가 가능합니다.
  * 장바구니 담기 및 수량 변경 시 유효성 검사와 구매 제한이 적용됩니다.
  * 장바구니 항목의 상세 정보(상품명, 옵션명, 이미지, 가격, 마감일 등)를 확인할 수 있습니다.

* **기타**
  * 데이터베이스 테이블명이 일부 복수형으로 변경되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->