### PR TITLE
Google OAuth 소셜 로그인 기능 구현

### DIFF
--- a/src/main/java/com/ururulab/ururu/auth/controller/JwtRefreshController.java
+++ b/src/main/java/com/ururulab/ururu/auth/controller/JwtRefreshController.java
@@ -2,10 +2,8 @@ package com.ururulab.ururu.auth.controller;
 
 import com.ururulab.ururu.auth.dto.request.RefreshTokenRequest;
 import com.ururulab.ururu.auth.dto.response.SocialLoginResponse;
-import com.ururulab.ururu.auth.exception.MissingAuthorizationHeaderException;
 import com.ururulab.ururu.auth.exception.RedisConnectionException;
 import com.ururulab.ururu.auth.service.JwtRefreshService;
-import com.ururulab.ururu.auth.jwt.JwtTokenProvider;
 import com.ururulab.ururu.global.common.dto.ApiResponseFormat;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -19,43 +17,24 @@ import org.springframework.web.bind.annotation.*;
 @RequestMapping("/auth")
 @RequiredArgsConstructor
 public final class JwtRefreshController {
+
     private final JwtRefreshService jwtRefreshService;
-    private final JwtTokenProvider jwtTokenProvider;
 
     @PostMapping("/refresh")
     public ResponseEntity<ApiResponseFormat<SocialLoginResponse>> refreshToken(
-            @Valid @RequestBody RefreshTokenRequest request
+            @Valid @RequestBody final RefreshTokenRequest request
     ) {
-        final String newAccessToken = jwtRefreshService.refreshAccessToken(request.refreshToken());
-        final String refreshToken = request.refreshToken();
-        final Long expiresIn = jwtTokenProvider.getAccessTokenExpiry();
-        final Long memberId = jwtTokenProvider.getMemberId(newAccessToken);
-        final String email = jwtTokenProvider.getEmail(newAccessToken);
-        final String role = jwtTokenProvider.getRole(newAccessToken);
-
-        SocialLoginResponse responseBody = SocialLoginResponse.of(
-                newAccessToken,
-                refreshToken,
-                expiresIn,
-                SocialLoginResponse.MemberInfo.of(memberId, email, null, null)
-        );
-        return ResponseEntity.ok(ApiResponseFormat.success("토큰이 갱신되었습니다.", responseBody));
+        final SocialLoginResponse response = jwtRefreshService.refreshAccessToken(request.refreshToken());
+        return ResponseEntity.ok(ApiResponseFormat.success("토큰이 갱신되었습니다.", response));
     }
 
     @PostMapping("/logout")
     public ResponseEntity<ApiResponseFormat<Void>> logout(
-            @RequestHeader("Authorization") String authorization
+            @RequestHeader("Authorization") final String authorization
     ) {
-        if (authorization == null || !authorization.startsWith("Bearer ")) {
-            throw new MissingAuthorizationHeaderException("Authorization 헤더가 필요합니다.");
-        }
-
-        final String accessToken = authorization.substring(7);
-        final Long memberId = jwtTokenProvider.getMemberId(accessToken);
-
         try {
-            jwtRefreshService.logout(memberId, accessToken);
-        } catch (RedisConnectionFailureException e) {
+            jwtRefreshService.logout(authorization);
+        } catch (final RedisConnectionFailureException e) {
             throw new RedisConnectionException("일시적인 서버 오류입니다.", e);
         }
 

--- a/src/main/java/com/ururulab/ururu/auth/dto/info/GoogleUserInfo.java
+++ b/src/main/java/com/ururulab/ururu/auth/dto/info/GoogleUserInfo.java
@@ -1,0 +1,4 @@
+package com.ururulab.ururu.auth.dto.info;
+
+public class GoogleUserInfo {
+}

--- a/src/main/java/com/ururulab/ururu/auth/dto/info/GoogleUserInfo.java
+++ b/src/main/java/com/ururulab/ururu/auth/dto/info/GoogleUserInfo.java
@@ -1,4 +1,29 @@
 package com.ururulab.ururu.auth.dto.info;
 
-public class GoogleUserInfo {
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record GoogleUserInfo(
+        String id,
+        String email,
+        @JsonProperty("verified_email") boolean verifiedEmail,
+        String name,
+        @JsonProperty("given_name") String givenName,
+        @JsonProperty("family_name") String familyName,
+        String picture,
+        String locale
+) {
+
+    public static GoogleUserInfo of(
+            final String id,
+            final String email,
+            final boolean verifiedEmail,
+            final String name,
+            final String givenName,
+            final String familyName,
+            final String picture,
+            final String locale
+    ) {
+        return new GoogleUserInfo(id, email, verifiedEmail, name,
+                givenName, familyName, picture, locale);
+    }
 }

--- a/src/main/java/com/ururulab/ururu/auth/dto/info/SocialMemberInfo.java
+++ b/src/main/java/com/ururulab/ururu/auth/dto/info/SocialMemberInfo.java
@@ -95,10 +95,11 @@ public record SocialMemberInfo(
             throw new IllegalArgumentException("구글 회원 정보가 없습니다");
         }
 
-        final String socialId = (String) attributes.get("sub");
-        if (socialId == null || socialId.isBlank()) {
+        final Object idObj = attributes.get("id");
+        if (idObj == null) {
             throw new IllegalArgumentException("구글 회원 ID가 없습니다");
         }
+        final String socialId = String.valueOf(idObj);
 
         final String email = (String) attributes.get("email");
         final String nickname = (String) attributes.get("name");

--- a/src/main/java/com/ururulab/ururu/auth/dto/response/GoogleTokenResponse.java
+++ b/src/main/java/com/ururulab/ururu/auth/dto/response/GoogleTokenResponse.java
@@ -1,4 +1,25 @@
 package com.ururulab.ururu.auth.dto.response;
 
-public class GoogleTokenResponse {
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record GoogleTokenResponse(
+        @JsonProperty("access_token") String accessToken,
+        @JsonProperty("expires_in") int expiresIn,
+        @JsonProperty("refresh_token") String refreshToken,
+        String scope,
+        @JsonProperty("token_type") String tokenType,
+        @JsonProperty("id_token") String idToken
+) {
+
+    public static GoogleTokenResponse of(
+            final String accessToken,
+            final int expiresIn,
+            final String refreshToken,
+            final String scope,
+            final String tokenType,
+            final String idToken
+    ) {
+        return new GoogleTokenResponse(accessToken, expiresIn, refreshToken,
+                scope, tokenType, idToken);
+    }
 }

--- a/src/main/java/com/ururulab/ururu/auth/dto/response/GoogleTokenResponse.java
+++ b/src/main/java/com/ururulab/ururu/auth/dto/response/GoogleTokenResponse.java
@@ -1,0 +1,4 @@
+package com.ururulab.ururu.auth.dto.response;
+
+public class GoogleTokenResponse {
+}

--- a/src/main/java/com/ururulab/ururu/auth/oauth/GoogleOAuthProperties.java
+++ b/src/main/java/com/ururulab/ururu/auth/oauth/GoogleOAuthProperties.java
@@ -1,0 +1,35 @@
+package com.ururulab.ururu.auth.oauth;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+import org.springframework.web.util.UriComponentsBuilder;
+
+@Getter
+@Setter
+@Component
+@ConfigurationProperties(prefix = "oauth2.google")
+public final class GoogleOAuthProperties {
+    private String clientId;
+    private String clientSecret;
+    private String redirectUri;
+    private String authorizationUri;
+    private String tokenUri;
+    private String userInfoUri;
+    private String scope;
+
+    public String buildAuthorizationUrl(final String state) {
+        return UriComponentsBuilder
+                .fromUriString(authorizationUri)
+                .queryParam("client_id", clientId)
+                .queryParam("redirect_uri", redirectUri)
+                .queryParam("response_type", "code")
+                .queryParam("scope", scope)
+                .queryParam("state", state)
+                .queryParam("access_type", "offline")
+                .queryParam("prompt", "consent")
+                .build()
+                .toUriString();
+    }
+}

--- a/src/main/java/com/ururulab/ururu/auth/oauth/GoogleOAuthProperties.java
+++ b/src/main/java/com/ururulab/ururu/auth/oauth/GoogleOAuthProperties.java
@@ -6,30 +6,59 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.stereotype.Component;
 import org.springframework.web.util.UriComponentsBuilder;
 
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+
 @Getter
 @Setter
 @Component
 @ConfigurationProperties(prefix = "oauth2.google")
 public final class GoogleOAuthProperties {
+
+    private static final String RESPONSE_TYPE = "code";
+    private static final String GRANT_TYPE = "authorization_code";
+    private static final String ACCESS_TYPE = "offline";
+    private static final String PROMPT = "consent";
+
     private String clientId;
     private String clientSecret;
     private String redirectUri;
     private String authorizationUri;
     private String tokenUri;
-    private String userInfoUri;
+    private String memberInfoUri;
     private String scope;
 
     public String buildAuthorizationUrl(final String state) {
-        return UriComponentsBuilder
-                .fromUriString(authorizationUri)
+        if (state == null || state.isBlank()) {
+            throw new IllegalArgumentException("state 매개변수는 필수입니다");
+        }
+        return UriComponentsBuilder.fromUriString(authorizationUri)
                 .queryParam("client_id", clientId)
                 .queryParam("redirect_uri", redirectUri)
-                .queryParam("response_type", "code")
+                .queryParam("response_type", RESPONSE_TYPE)
                 .queryParam("scope", scope)
                 .queryParam("state", state)
-                .queryParam("access_type", "offline")
-                .queryParam("prompt", "consent")
+                .queryParam("access_type", ACCESS_TYPE)
+                .queryParam("prompt", PROMPT)
                 .build()
                 .toUriString();
+    }
+
+    public String buildTokenRequestBody(final String code) {
+        if (code == null || code.isBlank()) {
+            throw new IllegalArgumentException("인증 코드는 필수입니다");
+        }
+        try {
+            return String.format(
+                    "grant_type=%s&client_id=%s&client_secret=%s&redirect_uri=%s&code=%s",
+                    URLEncoder.encode(GRANT_TYPE, StandardCharsets.UTF_8),
+                    URLEncoder.encode(clientId, StandardCharsets.UTF_8),
+                    URLEncoder.encode(clientSecret, StandardCharsets.UTF_8),
+                    URLEncoder.encode(redirectUri, StandardCharsets.UTF_8),
+                    URLEncoder.encode(code, StandardCharsets.UTF_8)
+            );
+        } catch (final Exception e) {
+            throw new IllegalStateException("URL 인코딩 실패", e);
+        }
     }
 }

--- a/src/main/java/com/ururulab/ururu/auth/service/JwtRefreshService.java
+++ b/src/main/java/com/ururulab/ururu/auth/service/JwtRefreshService.java
@@ -1,6 +1,9 @@
 package com.ururulab.ururu.auth.service;
 
+import com.ururulab.ururu.auth.dto.response.SocialLoginResponse;
 import com.ururulab.ururu.auth.exception.InvalidRefreshTokenException;
+import com.ururulab.ururu.auth.exception.MissingAuthorizationHeaderException;
+import com.ururulab.ururu.auth.jwt.JwtProperties;
 import com.ururulab.ururu.auth.jwt.JwtTokenProvider;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.redis.core.StringRedisTemplate;
@@ -13,56 +16,78 @@ import java.time.Duration;
 public final class JwtRefreshService {
     private static final String REFRESH_KEY_PREFIX = "refresh:";
     private static final String BLACKLIST_KEY_PREFIX = "blacklist:";
+    private static final String BEARER_PREFIX = "Bearer ";
 
     private final JwtTokenProvider jwtTokenProvider;
+    private final JwtProperties jwtProperties;
     private final StringRedisTemplate redisTemplate;
 
-
     public void storeRefreshToken(final Long memberId, final String refreshToken) {
-        long expirySeconds = jwtTokenProvider.getRefreshTokenExpirySeconds();
-        String key = REFRESH_KEY_PREFIX + memberId;
+        final long expirySeconds = jwtTokenProvider.getRefreshTokenExpirySeconds();
+        final String key = REFRESH_KEY_PREFIX + memberId;
         redisTemplate.opsForValue().set(key, refreshToken, Duration.ofSeconds(expirySeconds));
     }
 
-    public String refreshAccessToken(final String refreshToken) {
+    public SocialLoginResponse refreshAccessToken(final String refreshToken) {
         if (!jwtTokenProvider.validateToken(refreshToken)) {
             throw new InvalidRefreshTokenException("유효하지 않은 리프레시 토큰입니다.");
         }
         if (!jwtTokenProvider.isRefreshToken(refreshToken)) {
             throw new InvalidRefreshTokenException("리프레시 토큰이 아닙니다.");
         }
-        String tokenId = jwtTokenProvider.getTokenId(refreshToken);
+
+        final String tokenId = jwtTokenProvider.getTokenId(refreshToken);
         if (isTokenBlacklisted(tokenId)) {
             throw new InvalidRefreshTokenException("만료되었거나 철회된 토큰입니다.");
         }
-        Long memberId = jwtTokenProvider.getMemberId(refreshToken);
-        String key = REFRESH_KEY_PREFIX + memberId;
-        String storedToken = redisTemplate.opsForValue().get(key);
+
+        final Long memberId = jwtTokenProvider.getMemberId(refreshToken);
+        final String key = REFRESH_KEY_PREFIX + memberId;
+        final String storedToken = redisTemplate.opsForValue().get(key);
+
         if (storedToken == null || !storedToken.equals(refreshToken)) {
             throw new InvalidRefreshTokenException("이미 사용되었거나 유효하지 않은 토큰입니다.");
         }
-        String newAccessToken = jwtTokenProvider.generateAccessToken(
-                memberId,
-                jwtTokenProvider.getEmail(refreshToken),
-                jwtTokenProvider.getRole(refreshToken)
+
+        final String email = jwtTokenProvider.getEmail(refreshToken);
+        final String role = jwtTokenProvider.getRole(refreshToken);
+
+        final String newAccessToken = jwtTokenProvider.generateAccessToken(memberId, email, role);
+
+        return SocialLoginResponse.of(
+                newAccessToken,
+                refreshToken,
+                jwtProperties.getAccessTokenExpiry(),
+                SocialLoginResponse.MemberInfo.of(memberId, email, null, null)
         );
-        return newAccessToken;
     }
 
-    public void logout(final Long memberId, final String accessToken) {
-        String refreshKey = REFRESH_KEY_PREFIX + memberId;
+    public void logout(final String authorization) {
+        final String accessToken = extractTokenFromBearer(authorization);
+        final Long memberId = jwtTokenProvider.getMemberId(accessToken);
+
+        final String refreshKey = REFRESH_KEY_PREFIX + memberId;
         redisTemplate.delete(refreshKey);
-        String tokenId = jwtTokenProvider.getTokenId(accessToken);
-        long expiry = jwtTokenProvider.getRemainingExpiry(accessToken);
+
+        final String tokenId = jwtTokenProvider.getTokenId(accessToken);
+        final long expiry = jwtTokenProvider.getRemainingExpiry(accessToken);
+
         if (tokenId != null && expiry > 0) {
-            String blacklistKey = BLACKLIST_KEY_PREFIX + tokenId;
+            final String blacklistKey = BLACKLIST_KEY_PREFIX + tokenId;
             redisTemplate.opsForValue().set(blacklistKey, "1", Duration.ofSeconds(expiry));
         }
     }
 
     public boolean isTokenBlacklisted(final String tokenId) {
         if (tokenId == null) return false;
-        String blacklistKey = BLACKLIST_KEY_PREFIX + tokenId;
+        final String blacklistKey = BLACKLIST_KEY_PREFIX + tokenId;
         return Boolean.TRUE.equals(redisTemplate.hasKey(blacklistKey));
+    }
+
+    private String extractTokenFromBearer(final String bearerToken) {
+        if (bearerToken == null || !bearerToken.startsWith(BEARER_PREFIX)) {
+            throw new MissingAuthorizationHeaderException("Authorization 헤더가 필요합니다.");
+        }
+        return bearerToken.substring(BEARER_PREFIX.length());
     }
 }

--- a/src/main/java/com/ururulab/ururu/auth/service/social/GoogleLoginService.java
+++ b/src/main/java/com/ururulab/ururu/auth/service/social/GoogleLoginService.java
@@ -1,0 +1,4 @@
+package com.ururulab.ururu.auth.service.social;
+
+public class GoogleLoginService {
+}

--- a/src/main/java/com/ururulab/ururu/auth/service/social/GoogleLoginService.java
+++ b/src/main/java/com/ururulab/ururu/auth/service/social/GoogleLoginService.java
@@ -1,4 +1,184 @@
 package com.ururulab.ururu.auth.service.social;
 
-public class GoogleLoginService {
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.ururulab.ururu.auth.dto.info.SocialMemberInfo;
+import com.ururulab.ururu.auth.dto.response.SocialLoginResponse;
+import com.ururulab.ururu.auth.exception.SocialMemberInfoException;
+import com.ururulab.ururu.auth.exception.SocialTokenExchangeException;
+import com.ururulab.ururu.auth.jwt.JwtProperties;
+import com.ururulab.ururu.auth.jwt.JwtTokenProvider;
+import com.ururulab.ururu.auth.oauth.GoogleOAuthProperties;
+import com.ururulab.ururu.auth.service.SocialLoginService;
+import com.ururulab.ururu.member.domain.entity.Member;
+import com.ururulab.ururu.member.domain.entity.enumerated.SocialProvider;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestClient;
+import org.springframework.web.client.RestClientException;
+
+import java.util.Map;
+
+/**
+ * 구글 소셜 로그인 서비스.
+ * KakaoLoginService와 동일한 패턴으로 구현됨.
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public final class GoogleLoginService implements SocialLoginService {
+
+    private static final String BEARER_PREFIX = "Bearer ";
+    private static final int SENSITIVE_DATA_PREVIEW_LENGTH = 10;
+    private static final String MASKED_DATA_PLACEHOLDER = "***";
+
+    private final GoogleOAuthProperties googleOAuthProperties;
+    private final JwtTokenProvider jwtTokenProvider;
+    private final JwtProperties jwtProperties;
+    private final RestClient restClient;
+    private final ObjectMapper objectMapper;
+    private final MemberTransactionService memberTransactionService;
+
+    @Override
+    public String getAuthorizationUrl(final String state) {
+        if (state == null || state.isBlank()) {
+            throw new IllegalArgumentException("CSRF 방지를 위한 state 파라미터는 필수입니다.");
+        }
+        return googleOAuthProperties.buildAuthorizationUrl(state);
+    }
+
+    @Override
+    public String getAccessToken(final String code) {
+        if (code == null || code.isBlank()) {
+            throw new IllegalArgumentException("인증 코드는 필수입니다.");
+        }
+
+        try {
+            final String requestBody = buildTokenRequestBody(code);
+            log.debug("Requesting Google access token with code: {}", maskSensitiveData(code));
+
+            final String response = restClient.post()
+                    .uri(googleOAuthProperties.getTokenUri())
+                    .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_FORM_URLENCODED_VALUE)
+                    .body(requestBody)
+                    .retrieve()
+                    .body(String.class);
+
+            final String accessToken = extractAccessTokenFromResponse(response);
+            log.info("Google access token acquired successfully");
+            return accessToken;
+
+        } catch (final RestClientException e) {
+            log.error("Failed to get Google access token", e);
+            throw new SocialTokenExchangeException("Google 토큰 교환에 실패했습니다.", e);
+        }
+    }
+
+    @Override
+    public SocialMemberInfo getMemberInfo(final String accessToken) {
+        if (accessToken == null || accessToken.isBlank()) {
+            throw new IllegalArgumentException("액세스 토큰은 필수입니다.");
+        }
+
+        try {
+            log.debug("Requesting Google user info with token: {}", maskSensitiveData(accessToken));
+
+            final String response = restClient.get()
+                    .uri(googleOAuthProperties.getUserInfoUri())
+                    .header(HttpHeaders.AUTHORIZATION, BEARER_PREFIX + accessToken)
+                    .retrieve()
+                    .body(String.class);
+
+            final SocialMemberInfo memberInfo = parseMemberInfoFromResponse(response);
+            log.info("Google user info acquired for member: {}",
+                    maskSensitiveData(memberInfo.email()));
+            return memberInfo;
+
+        } catch (final RestClientException e) {
+            log.error("Failed to get Google user info", e);
+            throw new SocialMemberInfoException("Google 사용자 정보 조회에 실패했습니다.", e);
+        }
+    }
+
+    @Override
+    public SocialLoginResponse processLogin(final String code) {
+        if (code == null || code.isBlank()) {
+            throw new IllegalArgumentException("인증 코드는 필수입니다.");
+        }
+
+        final String accessToken = getAccessToken(code);
+        final SocialMemberInfo socialMemberInfo = getMemberInfo(accessToken);
+
+        final Member member = memberTransactionService.findOrCreateMember(socialMemberInfo);
+
+        final String jwtAccessToken = jwtTokenProvider.generateAccessToken(
+                member.getId(),
+                member.getEmail(),
+                member.getRole().name()
+        );
+        final String jwtRefreshToken = jwtTokenProvider.generateRefreshToken(member.getId());
+
+        return SocialLoginResponse.of(
+                jwtAccessToken,
+                jwtRefreshToken,
+                jwtProperties.getAccessTokenExpiry(),
+                SocialLoginResponse.MemberInfo.of(
+                        member.getId(),
+                        member.getEmail(),
+                        member.getNickname(),
+                        member.getProfileImage()
+                )
+        );
+    }
+
+    @Override
+    public SocialProvider getProvider() {
+        return SocialProvider.GOOGLE;
+    }
+
+    private String buildTokenRequestBody(final String code) {
+        return "grant_type=authorization_code" +
+                "&client_id=" + googleOAuthProperties.getClientId() +
+                "&client_secret=" + googleOAuthProperties.getClientSecret() +
+                "&redirect_uri=" + googleOAuthProperties.getRedirectUri() +
+                "&code=" + code;
+    }
+
+    private String extractAccessTokenFromResponse(final String responseBody) {
+        try {
+            final JsonNode jsonNode = objectMapper.readTree(responseBody);
+            final JsonNode accessTokenNode = jsonNode.get("access_token");
+
+            if (accessTokenNode == null || accessTokenNode.isNull()) {
+                throw new SocialTokenExchangeException("응답에 액세스 토큰이 없습니다.");
+            }
+
+            return accessTokenNode.asText();
+        } catch (final Exception e) {
+            log.error("Failed to parse access token from response");
+            throw new SocialTokenExchangeException("액세스 토큰 파싱에 실패했습니다.", e);
+        }
+    }
+
+    private SocialMemberInfo parseMemberInfoFromResponse(final String responseBody) {
+        try {
+            final JsonNode jsonNode = objectMapper.readTree(responseBody);
+            @SuppressWarnings("unchecked")
+            final Map<String, Object> attributes = objectMapper.convertValue(jsonNode, Map.class);
+            return SocialMemberInfo.fromGoogleAttributes(attributes);
+        } catch (final Exception e) {
+            log.error("Failed to parse member info from response");
+            throw new SocialMemberInfoException("회원 정보 파싱에 실패했습니다.", e);
+        }
+    }
+
+    private String maskSensitiveData(final String data) {
+        if (data == null || data.length() <= SENSITIVE_DATA_PREVIEW_LENGTH) {
+            return MASKED_DATA_PLACEHOLDER;
+        }
+        return data.substring(0, SENSITIVE_DATA_PREVIEW_LENGTH) + "...";
+    }
 }


### PR DESCRIPTION
## ⭐️ Issue Number
- #69 

## 🚩 Summary

- Google OAuth 2.0 기반 소셜 로그인 기능 구현
- Google 소셜 로그인 토큰 응답 DTO 구조 개선
- SocialMemberInfo에 Google 속성 파싱 기능 추가
- Google 소셜 로그인 서비스 로직 구현
- Google 사용자 정보 응답 DTO 구조 정의
- JwtRefreshController의 응답 타입을 ApiResponseFormat으로 변경하여 API 응답 일관성 확보

## 🛠️ Technical Concerns

- Google OAuth 2.0 인증 플로우 구현 시 보안 고려사항 검토 필요
- Google API 응답 형식 변경에 대한 호환성 대응 방안 검토
- 소셜 로그인 서비스 간 공통 인터페이스 일관성 유지
- JWT 토큰 응답 형식 표준화로 인한 기존 클라이언트 호환성 확인 필요

## 🙂 To Reviewer

- Google OAuth 설정 및 콜백 URL 검증 
- SocialMemberInfo 파싱 로직의 null 처리 검토 
- API 응답 형식 변경으로 인한 프론트엔드 영향도 검토 
- Google 소셜 로그인 테스트 시나리오 및 에러 핸들링 검토 

## 📋 To Do
 - [x] Google OAuth 설정 클래스 구현
 - [x]  Google 소셜 로그인 서비스 구현
 - [x] Google 사용자 정보 DTO 구현
 - [x] SocialMemberInfo Google 속성 파싱 로직 추가
 - [x] JwtRefreshController 응답 형식 표준화
 - [ ] Google 소셜 로그인 통합 테스트 작성
 - [ ] Google OAuth 콜백 URL 환경별 설정 확인
 - [ ]  프론트엔드 연동 테스트

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


* **신규 기능**
  * 구글 소셜 로그인을 지원하는 기능이 추가되었습니다.
  * 구글 OAuth2 인증 및 토큰 발급, 사용자 정보 조회 기능이 도입되었습니다.
  * 구글 관련 사용자 정보 및 토큰 응답을 처리하는 데이터 구조가 추가되었습니다.
  * 구글 OAuth2 설정을 위한 구성 클래스가 추가되었습니다.
  * 구글 OAuth 콜백을 처리하는 기능이 인증 컨트롤러에 추가되었습니다.

* **버그 수정**
  * 구글 사용자 정보 추출 방식이 개선되어 더 정확한 정보 처리가 가능합니다.

* **리팩터링**
  * 인증 관련 응답 포맷이 일관성 있게 변경되었습니다.
  * 토큰 갱신 및 로그아웃 처리 로직이 간소화되고 서비스 계층으로 위임되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->