### PR TITLE
BaseEntity를 JPA Auditing 방식으로 변경

### DIFF
--- a/src/main/java/com/ururulab/ururu/UruruApplication.java
+++ b/src/main/java/com/ururulab/ururu/UruruApplication.java
@@ -1,9 +1,7 @@
 package com.ururulab.ururu;
 
-import com.ururulab.ururu.auth.jwt.JwtProperties;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.scheduling.annotation.EnableAsync;
 
 @EnableAsync

--- a/src/main/java/com/ururulab/ururu/global/config/JpaAuditingConfig.java
+++ b/src/main/java/com/ururulab/ururu/global/config/JpaAuditingConfig.java
@@ -1,0 +1,9 @@
+package com.ururulab.ururu.global.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing
+public class JpaAuditingConfig {
+} 

--- a/src/main/java/com/ururulab/ururu/global/domain/entity/BaseEntity.java
+++ b/src/main/java/com/ururulab/ururu/global/domain/entity/BaseEntity.java
@@ -1,31 +1,25 @@
 package com.ururulab.ururu.global.domain.entity;
 
 import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
 import jakarta.persistence.MappedSuperclass;
-import jakarta.persistence.PrePersist;
-import jakarta.persistence.PreUpdate;
 import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.time.ZonedDateTime;
 
 @Getter
 @MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
 public abstract class BaseEntity {
 
+    @CreatedDate
     @Column(nullable = false, updatable = false)
-    private ZonedDateTime createdAt; // 생성 시간
+    private ZonedDateTime createdAt;
 
+    @LastModifiedDate
     @Column(nullable = false)
-    private ZonedDateTime updatedAt; // 수정 시간
-
-    @PrePersist
-    public void prePersist() {
-        this.createdAt = ZonedDateTime.now();
-        this.updatedAt = ZonedDateTime.now();
-    }
-
-    @PreUpdate
-    public void preUpdate() {
-        this.updatedAt = ZonedDateTime.now();
-    }
+    private ZonedDateTime updatedAt;
 }


### PR DESCRIPTION
## ⭐️ Issue Number
- #85 

## 🚩 Summary

- JPA Auditing 설정 클래스 추가 (JpaAuditingConfig)
- BaseEntity에서 @PrePersist/@PreUpdate 방식 제거
- @CreatedDate/@LastModifiedDate 방식으로 변경
- UruruApplication에서 불필요한 import 제거

## 🛠️ Technical Concerns

- 스프링 표준 Auditing 기능 사용으로 일관성 향상
- 커스텀 리스너 제거로 코드 간소화

## 🙂 To Reviewer
@taehyun32 
- JPA Auditing 방식으로 변경하여 스프링 표준을 따르도록 개선했습니다
- 기존 @PrePersist/@PreUpdate 방식에서 @CreatedDate/@LastModifiedDate 방식으로 변경하여 더 명확하고 확장 가능한 구조로 만들었습니다
- 코드 리뷰 부탁드립니다!

## 📋 To Do

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * JPA 감사(Auditing) 기능이 활성화되어 엔티티의 생성 및 수정 시간이 자동으로 관리됩니다.

* **리팩터링**
  * 엔티티의 생성 및 수정 시간 관리가 수동 방식에서 자동 감사 방식으로 변경되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->