### PR TITLE
AWS ALB 연동 및 ururu.o-r.kr 도메인 지원을 위한 백엔드 설정 완료

### DIFF
--- a/src/main/java/com/ururulab/ururu/auth/jwt/JwtCookieHelper.java
+++ b/src/main/java/com/ururulab/ururu/auth/jwt/JwtCookieHelper.java
@@ -9,7 +9,7 @@ import org.springframework.stereotype.Component;
 
 /**
  * JWT 토큰을 안전한 쿠키로 설정하는 헬퍼 클래스.
- * 
+ *
  * XSS 공격 방지를 위한 HttpOnly, HTTPS 통신을 위한 Secure,
  * CSRF 공격 방지를 위한 SameSite 속성을 적용합니다.
  */
@@ -21,46 +21,66 @@ public final class JwtCookieHelper {
     private static final String ACCESS_TOKEN_COOKIE_NAME = "access_token";
     private static final String REFRESH_TOKEN_COOKIE_NAME = "refresh_token";
     private static final String COOKIE_PATH = "/";
-    private static final String SAME_SITE_STRICT = "Strict";
-    
+
+    // 환경별 SameSite 정책 분리
+    private static final String SAME_SITE_DEV = "Lax";      // 개발환경: 관대한 정책
+    private static final String SAME_SITE_PROD = "None";    // 운영환경: 크로스 사이트 허용 (HTTPS 필수)
+
     private final JwtProperties jwtProperties;
+
+    @Value("${spring.profiles.active:prod}")
+    private String activeProfile;
+
+    // 도메인 설정을 위한 프로퍼티 (application.yml에서 설정)
+    @Value("${app.cookie.domain:}")
+    private String cookieDomain;
 
     public void setAccessTokenCookie(final HttpServletResponse response, final String accessToken) {
         final long maxAgeSeconds = jwtProperties.getAccessTokenExpiry() / 1000;
         setCookie(response, ACCESS_TOKEN_COOKIE_NAME, accessToken, (int) maxAgeSeconds);
-        
-        log.info("Access token cookie set with expiry: {} seconds", maxAgeSeconds);
+
+        log.debug("Access token cookie set with expiry: {} seconds for domain: {}",
+                maxAgeSeconds, getCookieDomain());
     }
 
     public void setRefreshTokenCookie(final HttpServletResponse response, final String refreshToken) {
         final long maxAgeSeconds = jwtProperties.getRefreshTokenExpiry() / 1000;
         setCookie(response, REFRESH_TOKEN_COOKIE_NAME, refreshToken, (int) maxAgeSeconds);
-        
-        log.info("Refresh token cookie set with expiry: {} seconds", maxAgeSeconds);
+
+        log.debug("Refresh token cookie set with expiry: {} seconds for domain: {}",
+                maxAgeSeconds, getCookieDomain());
     }
 
     public void clearTokenCookies(final HttpServletResponse response) {
         clearCookie(response, ACCESS_TOKEN_COOKIE_NAME);
         clearCookie(response, REFRESH_TOKEN_COOKIE_NAME);
-        
-        log.info("All JWT token cookies cleared");
+
+        log.info("All JWT token cookies cleared for domain: {}", getCookieDomain());
     }
 
-    private void setCookie(final HttpServletResponse response, final String name, 
-                          final String value, final int maxAgeSeconds) {
+    private void setCookie(final HttpServletResponse response, final String name,
+                           final String value, final int maxAgeSeconds) {
         final Cookie cookie = new Cookie(name, value);
-        
+
         cookie.setHttpOnly(true);
         cookie.setSecure(isSecureEnvironment());
         cookie.setPath(COOKIE_PATH);
         cookie.setMaxAge(maxAgeSeconds);
-        
+
+        // 도메인 설정 (운영환경에서만)
+        final String domain = getCookieDomain();
+        if (domain != null && !domain.isEmpty()) {
+            cookie.setDomain(domain);
+        }
+
         response.addCookie(cookie);
-        response.addHeader("Set-Cookie", 
-            String.format("%s=%s; Path=%s; Max-Age=%d; HttpOnly; %s; SameSite=%s",
-                name, value, COOKIE_PATH, maxAgeSeconds,
-                isSecureEnvironment() ? "Secure" : "",
-                SAME_SITE_STRICT));
+
+        // Set-Cookie 헤더에 SameSite 속성 추가
+        final String setCookieHeader = buildSetCookieHeader(name, value, maxAgeSeconds, domain);
+        response.addHeader("Set-Cookie", setCookieHeader);
+
+        log.debug("Cookie set: {} for domain: {} with SameSite: {}",
+                name, domain, getSameSitePolicy());
     }
 
     private void clearCookie(final HttpServletResponse response, final String name) {
@@ -69,26 +89,81 @@ public final class JwtCookieHelper {
         cookie.setSecure(isSecureEnvironment());
         cookie.setPath(COOKIE_PATH);
         cookie.setMaxAge(0);
-        
+
+        // 도메인 설정 (쿠키 삭제 시에도 동일한 도메인 필요)
+        final String domain = getCookieDomain();
+        if (domain != null && !domain.isEmpty()) {
+            cookie.setDomain(domain);
+        }
+
         response.addCookie(cookie);
-        response.addHeader("Set-Cookie", 
-            String.format("%s=; Path=%s; Max-Age=0; HttpOnly; %s; SameSite=%s",
-                name, COOKIE_PATH,
-                isSecureEnvironment() ? "Secure" : "",
-                SAME_SITE_STRICT));
+
+        // Set-Cookie 헤더에 SameSite 속성 추가
+        final String setCookieHeader = buildClearCookieHeader(name, domain);
+        response.addHeader("Set-Cookie", setCookieHeader);
     }
 
-    private static final String DEV_PROFILE = "dev";
-    
-    @Value("${spring.profiles.active:prod}")
-    private String activeProfile;
+    private String buildSetCookieHeader(final String name, final String value,
+                                        final int maxAgeSeconds, final String domain) {
+        final StringBuilder builder = new StringBuilder();
+        builder.append(String.format("%s=%s; Path=%s; Max-Age=%d; HttpOnly",
+                name, value, COOKIE_PATH, maxAgeSeconds));
+
+        if (isSecureEnvironment()) {
+            builder.append("; Secure");
+        }
+
+        if (domain != null && !domain.isEmpty()) {
+            builder.append("; Domain=").append(domain);
+        }
+
+        builder.append("; SameSite=").append(getSameSitePolicy());
+
+        return builder.toString();
+    }
+
+    private String buildClearCookieHeader(final String name, final String domain) {
+        final StringBuilder builder = new StringBuilder();
+        builder.append(String.format("%s=; Path=%s; Max-Age=0; HttpOnly", name, COOKIE_PATH));
+
+        if (isSecureEnvironment()) {
+            builder.append("; Secure");
+        }
+
+        if (domain != null && !domain.isEmpty()) {
+            builder.append("; Domain=").append(domain);
+        }
+
+        builder.append("; SameSite=").append(getSameSitePolicy());
+
+        return builder.toString();
+    }
+
+    /**
+     * 환경별 도메인 설정 반환
+     */
+    private String getCookieDomain() {
+        if (isDevelopmentProfile()) {
+            return null; // 개발환경에서는 도메인 설정 없음 (localhost)
+        }
+
+        // 운영환경에서는 설정값 사용하거나 기본값
+        return cookieDomain.isEmpty() ? ".o-r.kr" : cookieDomain;
+    }
+
+    /**
+     * 환경별 SameSite 정책 반환
+     */
+    private String getSameSitePolicy() {
+        return isDevelopmentProfile() ? SAME_SITE_DEV : SAME_SITE_PROD;
+    }
 
     private boolean isSecureEnvironment() {
         return !isDevelopmentProfile();
     }
 
     private boolean isDevelopmentProfile() {
-        return DEV_PROFILE.equals(activeProfile);
+        return "dev".equals(activeProfile);
     }
 
     private String maskSensitiveData(final String data) {

--- a/src/main/java/com/ururulab/ururu/global/config/CorsConfig.java
+++ b/src/main/java/com/ururulab/ururu/global/config/CorsConfig.java
@@ -47,7 +47,9 @@ public class CorsConfig {
         configuration.setAllowedOriginPatterns(List.of(
                 "http://localhost:*",
                 "http://127.0.0.1:*",
-                "https://*.vercel.app"
+                "https://*.vercel.app",
+                "https://ururu.o-r.kr",           // 운영 도메인 추가
+                "http://ururu.o-r.kr"             // HTTP도 임시로 추가 (나중에 HTTPS로 리다이렉트)
         ));
 
         configuration.setAllowedMethods(List.of(
@@ -73,6 +75,42 @@ public class CorsConfig {
         configuration.setMaxAge(PREFLIGHT_CACHE_SECONDS);
 
         return configuration;
+    }
+
+    @Bean
+    @Profile("prod")  // 운영환경용 추가
+    public CorsConfigurationSource prodCorsConfigurationSource() {
+        log.info("Configuring CORS for production environment");
+
+        final CorsConfiguration configuration = new CorsConfiguration();
+
+        // 운영환경에서는 특정 도메인만 허용
+        configuration.setAllowedOrigins(List.of(
+                "https://ururu.o-r.kr"  // HTTPS만 허용
+        ));
+
+        configuration.setAllowedMethods(List.of(
+                "GET", "POST", "PUT", "DELETE", "OPTIONS", "PATCH"
+        ));
+
+        configuration.setAllowedHeaders(List.of(
+                "Authorization", "Content-Type", "X-Requested-With",
+                "Accept", "Origin", "Cache-Control"
+        ));
+
+        configuration.setExposedHeaders(List.of(
+                "Authorization", "Content-Length", "X-Total-Count"
+        ));
+
+        configuration.setAllowCredentials(true);
+        configuration.setMaxAge(3600L);
+
+        final UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/api/**", configuration);
+        source.registerCorsConfiguration("/auth/**", configuration);
+        source.registerCorsConfiguration("/health/**", configuration);
+
+        return source;
     }
 
     private CorsConfiguration createPermissiveCorsConfiguration() {

--- a/src/main/java/com/ururulab/ururu/global/config/SecurityConfig.java
+++ b/src/main/java/com/ururulab/ururu/global/config/SecurityConfig.java
@@ -67,9 +67,12 @@ public class SecurityConfig {
      */
     @Bean
     @Profile("prod")
-    public SecurityFilterChain prodFilterChain(final HttpSecurity http) throws Exception {
+    public SecurityFilterChain prodFilterChain(
+            final HttpSecurity http,
+            final CorsConfigurationSource prodCorsConfigurationSource  // 운영용 CORS 주입
+    ) throws Exception {
         return http
-                .cors(AbstractHttpConfigurer::disable)
+                .cors(cors -> cors.configurationSource(prodCorsConfigurationSource))  // 운영용 CORS 적용
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers("/api/auth/**").permitAll()
                         .requestMatchers("/api/public/**").permitAll()

--- a/src/main/java/com/ururulab/ururu/global/controller/Controller.java
+++ b/src/main/java/com/ururulab/ururu/global/controller/Controller.java
@@ -1,18 +1,33 @@
 package com.ururulab.ururu.global.controller;
 
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.time.LocalDateTime;
+import java.util.Map;
+
 @RestController
 public class Controller {
 
-	@Value("${MESSAGE}")
-	private String message;
-
 	@GetMapping("/health")
-	public ResponseEntity<String> healthCheck() {
-		return ResponseEntity.ok(message);
+	public ResponseEntity<Map<String, Object>> healthCheck() {
+		try {
+			Map<String, Object> healthData = Map.of(
+					"status", "UP",
+					"timestamp", LocalDateTime.now(),
+					"service", "ururu-backend",
+					"message", "Health Check OK"
+			);
+			return ResponseEntity.ok(healthData); // HTTP 200 OK
+		} catch (Exception e) {
+			Map<String, Object> errorData = Map.of(
+					"status", "DOWN",
+					"timestamp", LocalDateTime.now(),
+					"service", "ururu-backend",
+					"error", e.getMessage()
+			);
+			return ResponseEntity.status(500).body(errorData); // HTTP 500
+		}
 	}
 }


### PR DESCRIPTION
## ⭐️ Issue Number
- #99 

## 🚩 Summary
- ALB 헬스 체크 안정화를 위한 컨트롤러 개선 (환경변수 의존성 제거, JSON 응답)
- ururu.o-r.kr 도메인 연동을 위한 JWT 쿠키 설정 개선 (환경별 도메인 및 SameSite 정책)
- 운영환경 CORS 설정 추가로 프론트엔드-백엔드 크로스 도메인 통신 지원
- 개발/운영 환경별 보안 정책 분리 및 Spring Security CORS 연결

## 🛠️ Technical Concerns
**ALB 헬스 체크 관련**
- 기존 @Value("${MESSAGE}") 환경변수 의존성으로 인한 헬스 체크 실패 가능성 제거
- Target Group 헬스 체크 경로를 /health로 설정 필요
- 헬스 체크 응답에 타임스탬프, 서비스명 포함으로 모니터링 강화

**JWT 쿠키 도메인 설정**
- 개발환경: 도메인 설정 없음 (localhost 호환)
- 운영환경: .o-r.kr 도메인으로 서브도메인 간 쿠키 공유
- SameSite 정책: 개발(Lax), 운영(None) - HTTPS 필수
- Private Repository 설정 필요: app.cookie.domain 프로퍼티

**CORS 정책 분리**
- 기존: @Profile("dev")만 존재
- 추가: @Profile("prod") 운영환경 전용 CORS 설정
- 운영환경에서는 https://ururu.o-r.kr 만 허용으로 보안 강화

## 🙂 To Reviewer
1. ALB 설정 확인: Target Group 헬스 체크 경로가 /health로 설정되어 있는지 확인
2. Private Repository 연동: UruruLab/Ururu-Backend-Config의 yml 파일에 app.cookie.domain 설정 추가 필요
3. 카카오 개발자 콘솔: Redirect URI에 https://ururu.o-r.kr/auth/oauth/kakao/callback 추가 필요
4. 환경별 동작 확인: 개발환경(localhost)과 운영환경(도메인) 모두에서 정상 작동하는지 검증
```
# 헬스 체크 테스트
curl http://localhost:8080/health

# CORS 헤더 확인
curl -H "Origin: https://ururu.o-r.kr" -H "Access-Control-Request-Method: POST" \
     -H "Access-Control-Request-Headers: Content-Type" \
     -X OPTIONS http://localhost:8080/api/auth/login
```
## 📋 To Do
배포 전 필요한 작업
- [ ] UruruLab/Ururu-Backend-Config 설정 업데이트
- [ ] AWS ALB Target Group 헬스 체크 경로를 /health로 설정
- [ ] 소셜 로그인 Redirect URI 추가
- [ ] DNS 설정: ururu.o-r.kr → ALB CNAME 레코드 설정
배포 후 검증
- [ ] ALB Target Group에서 인스턴스 상태가 Healthy로 변경되는지 확인
- [ ] https://ururu.o-r.kr/health 접속하여 헬스 체크 응답 확인
- [ ] 프론트엔드에서 백엔드 API 호출 시 CORS 에러 없이 정상 동작하는지 확인
- [ ] JWT 로그인 후 쿠키가 도메인 간 정상 전송되는지 확인