### PR TITLE
새 도메인(ururu.shop) 전환을 위한 CORS 설정 업데이트

### DIFF
--- a/src/main/java/com/ururulab/ururu/global/config/CorsConfig.java
+++ b/src/main/java/com/ururulab/ururu/global/config/CorsConfig.java
@@ -48,8 +48,8 @@ public class CorsConfig {
                 "http://localhost:*",
                 "http://127.0.0.1:*",
                 "https://*.vercel.app",
-                "https://ururu.o-r.kr",           // 운영 도메인 추가
-                "http://ururu.o-r.kr"             // HTTP도 임시로 추가 (나중에 HTTPS로 리다이렉트)
+                "https://www.ururu.shop",
+                "https://ururu.shop"
         ));
 
         configuration.setAllowedMethods(List.of(
@@ -86,7 +86,9 @@ public class CorsConfig {
 
         // 운영환경에서는 특정 도메인만 허용
         configuration.setAllowedOrigins(List.of(
-                "https://ururu.o-r.kr"  // HTTPS만 허용
+                "https://www.ururu.shop",        // 새 메인 프론트엔드 도메인
+                "https://ururu.shop",            // 루트 도메인
+                "https://ururu-beauty.vercel.app" // 임시
         ));
 
         configuration.setAllowedMethods(List.of(


### PR DESCRIPTION
## ⭐️ Issue Number
- #105 

## 🚩 Summary
CorsConfig.java
-  운영환경: `www.ururu.shop`, `ururu.shop` 도메인 추가
-  개발환경: 새 도메인 패턴 추가
-  기존 도메인 호환성 유지

## 🛠️ Technical Concerns
- 운영환경에서 새 도메인으로 API 호출 시 CORS 정책 적용 확인 필요
- DNS 전파 완료 후 실제 도메인에서 테스트 필요
- 기존 도메인과 새 도메인 모두 지원하는 전환 기간 고려

## 🙂 To Reviewer
- 운영환경과 개발환경 CORS 설정이 올바르게 분리되어 있는지 확인해주세요
- 새 도메인 패턴이 보안상 적절한지 검토 부탁드립니다
- 기존 기능에 영향이 없는지 확인해주세요

## 📋 To Do
- [x] CorsConfig.java 파일 수정
- [x] 운영환경 도메인 추가
- [x] 개발환경 도메인 패턴 추가
- [ ] 배포 후 새 도메인에서 API 호출 테스트
- [ ] DNS 전파 완료 후 최종 검증

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * CORS 허용 origin 목록이 업데이트되었습니다. 이제 "https://www.ururu.shop", "https://ururu.shop", "https://ururu-beauty.vercel.app"에서 서비스에 접근할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->