### PR TITLE
운영 환경 애플리케이션 시작 실패 문제 해결 - MySQL 예약어 충돌, CORS Bean 충돌 및 DDL 스키마 문제 해결

### DIFF
--- a/src/main/java/com/ururulab/ururu/global/config/SecurityConfig.java
+++ b/src/main/java/com/ururulab/ururu/global/config/SecurityConfig.java
@@ -2,6 +2,7 @@ package com.ururulab.ururu.global.config;
 
 import com.ururulab.ururu.auth.filter.JwtAuthenticationFilter;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
@@ -35,15 +36,15 @@ public class SecurityConfig {
     @Bean
     @Profile("dev")
     public SecurityFilterChain devFilterChain(
-            final HttpSecurity http, 
-            final CorsConfigurationSource corsConfigurationSource
+            final HttpSecurity http,
+            @Qualifier("corsConfigurationSource") final CorsConfigurationSource corsConfigurationSource
     ) throws Exception {
         return http
                 .cors(cors -> cors.configurationSource(corsConfigurationSource))
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers("/api/auth/**").permitAll()
                         .requestMatchers("/api/public/**").permitAll()
-                        .requestMatchers("/health", "/actuator/health").permitAll()
+                        .requestMatchers("/health").permitAll()
                         .requestMatchers("/swagger-ui/**", "/v3/api-docs/**").permitAll()
                         .requestMatchers("/h2-console/**").permitAll()
                         .anyRequest().authenticated()
@@ -69,14 +70,14 @@ public class SecurityConfig {
     @Profile("prod")
     public SecurityFilterChain prodFilterChain(
             final HttpSecurity http,
-            final CorsConfigurationSource prodCorsConfigurationSource  // 운영용 CORS 주입
+            @Qualifier("corsConfigurationSource") final CorsConfigurationSource corsConfigurationSource
     ) throws Exception {
         return http
-                .cors(cors -> cors.configurationSource(prodCorsConfigurationSource))  // 운영용 CORS 적용
+                .cors(cors -> cors.configurationSource(corsConfigurationSource))  // 운영용 CORS 적용
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers("/api/auth/**").permitAll()
                         .requestMatchers("/api/public/**").permitAll()
-                        .requestMatchers("/health", "/actuator/health").permitAll()
+                        .requestMatchers("/health").permitAll()
                         .anyRequest().authenticated()
                 )
                 .csrf(AbstractHttpConfigurer::disable)

--- a/src/main/java/com/ururulab/ururu/product/domain/entity/ProductNotice.java
+++ b/src/main/java/com/ururulab/ururu/product/domain/entity/ProductNotice.java
@@ -31,8 +31,8 @@ public class ProductNotice extends BaseEntity {
     @Column(nullable = false, length = EXPIRY_MAX)
     private String expiry; // 사용기한
 
-    @Column(nullable = false, columnDefinition = "TEXT")
-    private String usage; //사용 방법
+    @Column(name = "usage_guide", nullable = false, columnDefinition = "TEXT")
+    private String usage; //사용 방법 // 컬럼명: usage_guide (MySQL 예약어 회피용)
 
     @Column(nullable = false, length = MANUFACTURER_MAX)
     private String manufacturer; // 화장품 제조업자


### PR DESCRIPTION
## ⭐️ Issue Number
- #111 

## 🚩 Summary
운영 환경에서 Docker 컨테이너 실행 시 발생하는 애플리케이션 시작 실패 문제를 해결했습니다. MySQL 예약어 충돌, CORS Bean 충돌, DDL 스키마 문제 등 3가지 핵심 이슈를 한번에 수정했습니다.

**해결된 문제들:**

- ❌ ProductNotice.usage 필드가 MySQL 예약어와 충돌하여 DDL 생성 실패
- ❌ SecurityConfig에서 corsConfigurationSource Bean 충돌
- ❌ create-drop 모드에서 외래키 제약 충돌로 스키마 생성 실패
- ❌ Health check 엔드포인트 경로 불일치

## 🛠️ Technical Concerns
1. MySQL 예약어 충돌 해결
```
// Before
@Column(nullable = false, columnDefinition = "TEXT")
private String usage;

// After  
@Column(name = "usage_guide", nullable = false, columnDefinition = "TEXT")
private String usage;
```
2. CORS Bean 충돌 해결
```
// Before
public SecurityFilterChain prodFilterChain(
    final HttpSecurity http,
    final CorsConfigurationSource corsConfigurationSource
)

// After
public SecurityFilterChain prodFilterChain(
    final HttpSecurity http,
    @Qualifier("corsConfigurationSource") final CorsConfigurationSource corsConfigurationSource
)
```
3. Health Check 경로 간소화
```
// Before
.requestMatchers("/health", "/actuator/health").permitAll()

// After
.requestMatchers("/health").permitAll()
```
4. DDL 모드 변경
```
# 운영환경 validate ->update
spring:
  jpa:
    hibernate:
      ddl-auto: update
```


## 🙂 To Reviewer

- 테스트 환경: 로컬 Docker 환경에서 동일한 문제 재현 후 수정 검증 완료
- 호환성: 기존 API 호출 방식은 전혀 변경되지 않습니다 (필드명은 usage 그대로 유지)
- 데이터 안전성: usage → usage_guide 컬럼명 변경 시 기존 데이터는 수동 마이그레이션 필요할 수 있습니다
- 배포 전략: update 모드로 안전하게 배포 후 데이터 정합성 체크 권장

## 📋 To Do
**배포 후 확인사항:**

- [ ]  애플리케이션 정상 시작 확인 (docker logs -f ururu)
- [ ]  Health check 엔드포인트 정상 동작 확인 (curl http://localhost:8080/health)
- [ ]  ProductNotice 테이블 스키마 확인 (usage_guide 컬럼 생성 여부)
- [ ]  기존 usage 컬럼 데이터 마이그레이션 필요 시 수동 처리

**Config 리포지토리 업데이트 필요:**
- [ ]  application-prod.yml에 management, logging, server 설정 추가 권장
