### PR TITLE
포인트 잔액 및 내역 조회 API 구현

### DIFF
--- a/src/main/java/com/ururulab/ururu/payment/controller/PaymentController.java
+++ b/src/main/java/com/ururulab/ururu/payment/controller/PaymentController.java
@@ -24,7 +24,7 @@ import org.springframework.web.bind.annotation.*;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/payments")
-@Tag(name = "Payment", description = "결제 관련 API")
+@Tag(name = "결제", description = "결제 관련 API")
 public class PaymentController {
 
     private final PaymentService paymentService;

--- a/src/main/java/com/ururulab/ururu/payment/controller/PointController.java
+++ b/src/main/java/com/ururulab/ururu/payment/controller/PointController.java
@@ -1,0 +1,69 @@
+package com.ururulab.ururu.payment.controller;
+
+import com.ururulab.ururu.global.domain.dto.ApiResponseFormat;
+import com.ururulab.ururu.payment.dto.response.MemberPointResponse;
+import com.ururulab.ururu.payment.dto.response.PointTransactionListResponse;
+import com.ururulab.ururu.payment.service.PointService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/member/me")
+@Tag(name = "포인트", description = "포인트 관련 API")
+public class PointController {
+
+    private final PointService pointService;
+
+    @Operation(summary = "내 포인트 조회", description = "현재 보유한 포인트를 조회합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "포인트 조회 성공"),
+            @ApiResponse(responseCode = "401", description = "인증 실패"),
+            @ApiResponse(responseCode = "404", description = "존재하지 않는 회원")
+    })
+    @GetMapping("/points")
+    public ResponseEntity<ApiResponseFormat<MemberPointResponse>> getCurrentPoints(
+            @AuthenticationPrincipal Long memberId
+    ) {
+        log.debug("포인트 조회 요청 - 회원ID: {}", memberId);
+
+        MemberPointResponse response = pointService.getCurrentPoints(memberId);
+
+        return ResponseEntity.ok(
+                ApiResponseFormat.success("포인트 조회 성공", response)
+        );
+    }
+
+    @Operation(summary = "포인트 사용 내역 조회", description = "포인트 적립/사용 내역을 조회합니다. 타입과 소스로 필터링 가능합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "포인트 내역 조회 성공"),
+            @ApiResponse(responseCode = "401", description = "인증 실패"),
+            @ApiResponse(responseCode = "404", description = "존재하지 않는 회원")
+    })
+    @GetMapping("/point-transactions")
+    public ResponseEntity<ApiResponseFormat<PointTransactionListResponse>> getPointTransactions(
+            @AuthenticationPrincipal Long memberId,
+            @RequestParam(defaultValue = "all") String type,
+            @RequestParam(defaultValue = "all") String source,
+            @RequestParam(defaultValue = "1") int page,
+            @RequestParam(defaultValue = "10") int size
+    ) {
+        log.debug("포인트 내역 조회 요청 - 회원ID: {}, 타입: {}, 소스: {}, 페이지: {}, 크기: {}",
+                memberId, type, source, page, size);
+
+        PointTransactionListResponse response = pointService.getPointTransactions(
+                memberId, type, source, page, size);
+
+        return ResponseEntity.ok(
+                ApiResponseFormat.success("포인트 내역 조회 성공", response)
+        );
+    }
+}

--- a/src/main/java/com/ururulab/ururu/payment/domain/repository/PointTransactionRepository.java
+++ b/src/main/java/com/ururulab/ururu/payment/domain/repository/PointTransactionRepository.java
@@ -1,6 +1,10 @@
 package com.ururulab.ururu.payment.domain.repository;
 
 import com.ururulab.ururu.payment.domain.entity.PointTransaction;
+import com.ururulab.ururu.payment.domain.entity.enumerated.PointSource;
+import com.ururulab.ururu.payment.domain.entity.enumerated.PointType;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -10,11 +14,17 @@ import java.util.List;
 public interface PointTransactionRepository extends JpaRepository<PointTransaction, Long> {
 
     /**
-     * 회원별 포인트 이력 조회 (최신순)
-     * 마이페이지 포인트 내역에서 사용
+     * 회원별 포인트 거래내역 조회 (페이징, 필터링)
+     * type이나 source가 null이면 해당 조건 무시
      */
     @Query("SELECT pt FROM PointTransaction pt " +
             "WHERE pt.member.id = :memberId " +
-            "ORDER BY pt.createdAt DESC")
-    List<PointTransaction> findByMemberIdOrderByCreatedAtDesc(@Param("memberId") Long memberId);
+            "AND (:type IS NULL OR pt.type = :type) " +
+            "AND (:source IS NULL OR pt.source = :source)")
+    Page<PointTransaction> findByMemberIdWithFilters(
+            @Param("memberId") Long memberId,
+            @Param("type") PointType type,
+            @Param("source") PointSource source,
+            Pageable pageable
+    );
 }

--- a/src/main/java/com/ururulab/ururu/payment/dto/response/MemberPointResponse.java
+++ b/src/main/java/com/ururulab/ururu/payment/dto/response/MemberPointResponse.java
@@ -1,0 +1,10 @@
+package com.ururulab.ururu.payment.dto.response;
+
+/**
+ * 현재 포인트 조회 응답 DTO
+ * GET /api/member/me/points
+ */
+public record MemberPointResponse(
+        Integer currentPoints
+) {
+}

--- a/src/main/java/com/ururulab/ururu/payment/dto/response/PointTransactionListResponse.java
+++ b/src/main/java/com/ururulab/ururu/payment/dto/response/PointTransactionListResponse.java
@@ -1,0 +1,16 @@
+package com.ururulab.ururu.payment.dto.response;
+
+import java.util.List;
+
+/**
+ * 포인트 거래내역 목록 응답 DTO (페이징 포함)
+ * GET /api/member/me/point-transactions
+ */
+public record PointTransactionListResponse(
+        List<PointTransactionResponse> transactions,
+        Integer page,
+        Integer size,
+        Long total,
+        Integer totalPages
+) {
+}

--- a/src/main/java/com/ururulab/ururu/payment/dto/response/PointTransactionResponse.java
+++ b/src/main/java/com/ururulab/ururu/payment/dto/response/PointTransactionResponse.java
@@ -1,0 +1,19 @@
+package com.ururulab.ururu.payment.dto.response;
+
+import com.ururulab.ururu.payment.domain.entity.enumerated.PointSource;
+import com.ururulab.ururu.payment.domain.entity.enumerated.PointType;
+
+import java.time.Instant;
+
+/**
+ * 포인트 거래내역 개별 응답 DTO
+ */
+public record PointTransactionResponse(
+        Long id,
+        PointType type,
+        PointSource source,
+        Integer amount,
+        String reason,
+        Instant createdAt
+) {
+}

--- a/src/main/java/com/ururulab/ururu/payment/service/PointService.java
+++ b/src/main/java/com/ururulab/ururu/payment/service/PointService.java
@@ -1,0 +1,132 @@
+package com.ururulab.ururu.payment.service;
+
+import com.ururulab.ururu.global.exception.BusinessException;
+import com.ururulab.ururu.global.exception.error.ErrorCode;
+import com.ururulab.ururu.member.domain.entity.Member;
+import com.ururulab.ururu.member.domain.repository.MemberRepository;
+import com.ururulab.ururu.payment.dto.response.MemberPointResponse;
+import com.ururulab.ururu.payment.dto.response.PointTransactionListResponse;
+import com.ururulab.ururu.payment.dto.response.PointTransactionResponse;
+import com.ururulab.ururu.payment.domain.entity.PointTransaction;
+import com.ururulab.ururu.payment.domain.entity.enumerated.PointSource;
+import com.ururulab.ururu.payment.domain.entity.enumerated.PointType;
+import com.ururulab.ururu.payment.domain.repository.PointTransactionRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class PointService {
+
+    private final MemberRepository memberRepository;
+    private final PointTransactionRepository pointTransactionRepository;
+
+    /**
+     * 회원의 현재 포인트를 조회합니다.
+     *
+     * @param memberId 회원 ID
+     * @return 현재 포인트 정보
+     * @throws BusinessException 회원이 존재하지 않는 경우
+     */
+    @Transactional(readOnly = true)
+    public MemberPointResponse getCurrentPoints(Long memberId) {
+        log.debug("현재 포인트 조회 - 회원ID: {}", memberId);
+
+        Member member = findMemberById(memberId);
+        return new MemberPointResponse(member.getPoint());
+    }
+
+    /**
+     * 회원의 포인트 거래 내역을 조회합니다.
+     *
+     * @param memberId 회원 ID
+     * @param typeParam 포인트 타입 필터 ("all" 또는 실제 타입값)
+     * @param sourceParam 포인트 소스 필터 ("all" 또는 실제 소스값)
+     * @param page 페이지 번호 (1부터 시작)
+     * @param size 페이지 크기
+     * @return 포인트 거래 내역 목록 (페이징 포함)
+     * @throws BusinessException 회원이 존재하지 않는 경우
+     */
+    @Transactional(readOnly = true)
+    public PointTransactionListResponse getPointTransactions(
+            Long memberId,
+            String typeParam,
+            String sourceParam,
+            int page,
+            int size
+    ) {
+        log.debug("포인트 거래내역 조회 - 회원ID: {}, 타입: {}, 소스: {}, 페이지: {}, 크기: {}",
+                memberId, typeParam, sourceParam, page, size);
+
+        findMemberById(memberId);
+
+        PointType type = parsePointType(typeParam);
+        PointSource source = parsePointSource(sourceParam);
+
+        Pageable pageable = PageRequest.of(page - 1, size, Sort.by("createdAt").descending());
+
+        Page<PointTransaction> transactionPage = pointTransactionRepository.findByMemberIdWithFilters(
+                memberId, type, source, pageable);
+
+        List<PointTransactionResponse> transactions = transactionPage.getContent().stream()
+                .map(this::toPointTransactionResponse)
+                .toList();
+
+        return new PointTransactionListResponse(
+                transactions,
+                page,
+                size,
+                transactionPage.getTotalElements(),
+                transactionPage.getTotalPages()
+        );
+    }
+
+    private Member findMemberById(Long memberId) {
+        return memberRepository.findById(memberId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.MEMBER_NOT_FOUND));
+    }
+
+    private PointType parsePointType(String typeParam) {
+        if (typeParam == null || "all".equalsIgnoreCase(typeParam)) {
+            return null;
+        }
+        try {
+            return PointType.from(typeParam);
+        } catch (IllegalArgumentException e) {
+            log.warn("잘못된 포인트 타입 파라미터, all로 처리: {}", typeParam);
+            return null;
+        }
+    }
+
+    private PointSource parsePointSource(String sourceParam) {
+        if (sourceParam == null || "all".equalsIgnoreCase(sourceParam)) {
+            return null;
+        }
+        try {
+            return PointSource.from(sourceParam);
+        } catch (IllegalArgumentException e) {
+            log.warn("잘못된 포인트 소스 파라미터, all로 처리: {}", sourceParam);
+            return null;
+        }
+    }
+
+    private PointTransactionResponse toPointTransactionResponse(PointTransaction transaction) {
+        return new PointTransactionResponse(
+                transaction.getId(),
+                transaction.getType(),
+                transaction.getSource(),
+                transaction.getAmount(),
+                transaction.getReason(),
+                transaction.getCreatedAt()
+        );
+    }
+}

--- a/src/test/java/com/ururulab/ururu/payment/service/PointServiceTest.java
+++ b/src/test/java/com/ururulab/ururu/payment/service/PointServiceTest.java
@@ -1,0 +1,276 @@
+package com.ururulab.ururu.payment.service;
+
+import com.ururulab.ururu.global.domain.entity.enumerated.Gender;
+import com.ururulab.ururu.global.exception.BusinessException;
+import com.ururulab.ururu.global.exception.error.ErrorCode;
+import com.ururulab.ururu.member.domain.entity.Member;
+import com.ururulab.ururu.member.domain.entity.enumerated.Role;
+import com.ururulab.ururu.member.domain.entity.enumerated.SocialProvider;
+import com.ururulab.ururu.member.domain.repository.MemberRepository;
+import com.ururulab.ururu.payment.dto.response.MemberPointResponse;
+import com.ururulab.ururu.payment.dto.response.PointTransactionListResponse;
+import com.ururulab.ururu.payment.domain.entity.PointTransaction;
+import com.ururulab.ururu.payment.domain.entity.enumerated.PointSource;
+import com.ururulab.ururu.payment.domain.entity.enumerated.PointType;
+import com.ururulab.ururu.payment.domain.repository.PointTransactionRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("PointService 테스트")
+class PointServiceTest {
+
+    @InjectMocks
+    private PointService pointService;
+
+    @Mock
+    private MemberRepository memberRepository;
+
+    @Mock
+    private PointTransactionRepository pointTransactionRepository;
+
+    private static final Long MEMBER_ID = 1L;
+    private static final Integer MEMBER_POINTS = 5000;
+
+    private Member testMember;
+    private PointTransaction testTransaction;
+
+    @BeforeEach
+    void setUp() {
+        testMember = createTestMember();
+        testTransaction = createTestTransaction();
+    }
+
+    @Nested
+    @DisplayName("현재 포인트 조회")
+    class GetCurrentPointsTest {
+
+        @Test
+        @DisplayName("성공")
+        void getCurrentPoints_success() {
+            // given
+            given(memberRepository.findById(MEMBER_ID)).willReturn(Optional.of(testMember));
+
+            // when
+            MemberPointResponse result = pointService.getCurrentPoints(MEMBER_ID);
+
+            // then
+            assertThat(result.currentPoints()).isEqualTo(MEMBER_POINTS);
+            verify(memberRepository).findById(MEMBER_ID);
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 회원")
+        void getCurrentPoints_memberNotFound_fail() {
+            // given
+            given(memberRepository.findById(MEMBER_ID)).willReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> pointService.getCurrentPoints(MEMBER_ID))
+                    .isInstanceOf(BusinessException.class)
+                    .extracting(ex -> ((BusinessException) ex).getErrorCode())
+                    .isEqualTo(ErrorCode.MEMBER_NOT_FOUND);
+
+            verify(memberRepository).findById(MEMBER_ID);
+        }
+    }
+
+    @Nested
+    @DisplayName("포인트 거래내역 조회")
+    class GetPointTransactionsTest {
+
+        @Test
+        @DisplayName("성공 - 전체 조회")
+        void getPointTransactions_all_success() {
+            // given
+            Page<PointTransaction> transactionPage = new PageImpl<>(List.of(testTransaction));
+
+            given(memberRepository.findById(MEMBER_ID)).willReturn(Optional.of(testMember));
+            given(pointTransactionRepository.findByMemberIdWithFilters(
+                    eq(MEMBER_ID), isNull(), isNull(), any(Pageable.class)))
+                    .willReturn(transactionPage);
+
+            // when
+            PointTransactionListResponse result = pointService.getPointTransactions(
+                    MEMBER_ID, "all", "all", 1, 10);
+
+            // then
+            assertThat(result.transactions()).hasSize(1);
+            assertThat(result.page()).isEqualTo(1);
+            assertThat(result.size()).isEqualTo(10);
+            assertThat(result.total()).isEqualTo(1L);
+            assertThat(result.totalPages()).isEqualTo(1);
+
+            assertThat(result.transactions().get(0).id()).isEqualTo(1L);
+            assertThat(result.transactions().get(0).type()).isEqualTo(PointType.USED);
+            assertThat(result.transactions().get(0).source()).isEqualTo(PointSource.GROUPBUY);
+            assertThat(result.transactions().get(0).amount()).isEqualTo(2000);
+
+            verify(memberRepository).findById(MEMBER_ID);
+            verify(pointTransactionRepository).findByMemberIdWithFilters(
+                    eq(MEMBER_ID), isNull(), isNull(), any(Pageable.class));
+        }
+
+        @Test
+        @DisplayName("성공 - 타입 필터링")
+        void getPointTransactions_typeFilter_success() {
+            // given
+            Page<PointTransaction> transactionPage = new PageImpl<>(List.of(testTransaction));
+
+            given(memberRepository.findById(MEMBER_ID)).willReturn(Optional.of(testMember));
+            given(pointTransactionRepository.findByMemberIdWithFilters(
+                    eq(MEMBER_ID), eq(PointType.USED), isNull(), any(Pageable.class)))
+                    .willReturn(transactionPage);
+
+            // when
+            PointTransactionListResponse result = pointService.getPointTransactions(
+                    MEMBER_ID, "USED", "all", 1, 10);
+
+            // then
+            assertThat(result.transactions()).hasSize(1);
+            verify(pointTransactionRepository).findByMemberIdWithFilters(
+                    eq(MEMBER_ID), eq(PointType.USED), isNull(), any(Pageable.class));
+        }
+
+        @Test
+        @DisplayName("성공 - 소스 필터링")
+        void getPointTransactions_sourceFilter_success() {
+            // given
+            Page<PointTransaction> transactionPage = new PageImpl<>(List.of(testTransaction));
+
+            given(memberRepository.findById(MEMBER_ID)).willReturn(Optional.of(testMember));
+            given(pointTransactionRepository.findByMemberIdWithFilters(
+                    eq(MEMBER_ID), isNull(), eq(PointSource.GROUPBUY), any(Pageable.class)))
+                    .willReturn(transactionPage);
+
+            // when
+            PointTransactionListResponse result = pointService.getPointTransactions(
+                    MEMBER_ID, "all", "GROUPBUY", 1, 10);
+
+            // then
+            assertThat(result.transactions()).hasSize(1);
+            verify(pointTransactionRepository).findByMemberIdWithFilters(
+                    eq(MEMBER_ID), isNull(), eq(PointSource.GROUPBUY), any(Pageable.class));
+        }
+
+        @Test
+        @DisplayName("성공 - 잘못된 타입 파라미터는 all로 처리")
+        void getPointTransactions_invalidType_treatedAsAll() {
+            // given
+            Page<PointTransaction> transactionPage = new PageImpl<>(List.of(testTransaction));
+
+            given(memberRepository.findById(MEMBER_ID)).willReturn(Optional.of(testMember));
+            given(pointTransactionRepository.findByMemberIdWithFilters(
+                    eq(MEMBER_ID), isNull(), isNull(), any(Pageable.class)))
+                    .willReturn(transactionPage);
+
+            // when
+            PointTransactionListResponse result = pointService.getPointTransactions(
+                    MEMBER_ID, "INVALID_TYPE", "all", 1, 10);
+
+            // then
+            assertThat(result.transactions()).hasSize(1);
+            verify(pointTransactionRepository).findByMemberIdWithFilters(
+                    eq(MEMBER_ID), isNull(), isNull(), any(Pageable.class));
+        }
+
+        @Test
+        @DisplayName("성공 - 잘못된 소스 파라미터는 all로 처리")
+        void getPointTransactions_invalidSource_treatedAsAll() {
+            // given
+            Page<PointTransaction> transactionPage = new PageImpl<>(List.of(testTransaction));
+
+            given(memberRepository.findById(MEMBER_ID)).willReturn(Optional.of(testMember));
+            given(pointTransactionRepository.findByMemberIdWithFilters(
+                    eq(MEMBER_ID), isNull(), isNull(), any(Pageable.class)))
+                    .willReturn(transactionPage);
+
+            // when
+            PointTransactionListResponse result = pointService.getPointTransactions(
+                    MEMBER_ID, "all", "INVALID_SOURCE", 1, 10);
+
+            // then
+            assertThat(result.transactions()).hasSize(1);
+            verify(pointTransactionRepository).findByMemberIdWithFilters(
+                    eq(MEMBER_ID), isNull(), isNull(), any(Pageable.class));
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 회원")
+        void getPointTransactions_memberNotFound_fail() {
+            // given
+            given(memberRepository.findById(MEMBER_ID)).willReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> pointService.getPointTransactions(
+                    MEMBER_ID, "all", "all", 1, 10))
+                    .isInstanceOf(BusinessException.class)
+                    .extracting(ex -> ((BusinessException) ex).getErrorCode())
+                    .isEqualTo(ErrorCode.MEMBER_NOT_FOUND);
+
+            verify(memberRepository).findById(MEMBER_ID);
+            verify(pointTransactionRepository, never()).findByMemberIdWithFilters(
+                    anyLong(), any(), any(), any(Pageable.class));
+        }
+
+        @Test
+        @DisplayName("성공 - 빈 결과")
+        void getPointTransactions_emptyResult_success() {
+            // given
+            Page<PointTransaction> emptyPage = new PageImpl<>(List.of());
+
+            given(memberRepository.findById(MEMBER_ID)).willReturn(Optional.of(testMember));
+            given(pointTransactionRepository.findByMemberIdWithFilters(
+                    eq(MEMBER_ID), isNull(), isNull(), any(Pageable.class)))
+                    .willReturn(emptyPage);
+
+            // when
+            PointTransactionListResponse result = pointService.getPointTransactions(
+                    MEMBER_ID, "all", "all", 1, 10);
+
+            // then
+            assertThat(result.transactions()).isEmpty();
+            assertThat(result.page()).isEqualTo(1);
+            assertThat(result.size()).isEqualTo(10);
+            assertThat(result.total()).isEqualTo(0L);
+            assertThat(result.totalPages()).isEqualTo(1); // 빈 페이지도 totalPages는 1
+        }
+    }
+
+    private Member createTestMember() {
+        Member member = Member.of(
+                "테스트유저", "test@example.com", SocialProvider.KAKAO,
+                "social123", Gender.NONE, null, null, null, Role.NORMAL
+        );
+        ReflectionTestUtils.setField(member, "id", MEMBER_ID);
+        ReflectionTestUtils.setField(member, "point", MEMBER_POINTS);
+        return member;
+    }
+
+    private PointTransaction createTestTransaction() {
+        PointTransaction transaction = PointTransaction.createUsed(
+                testMember, PointSource.GROUPBUY, 2000, "공동구매 결제"
+        );
+        ReflectionTestUtils.setField(transaction, "id", 1L);
+        ReflectionTestUtils.setField(transaction, "createdAt", Instant.now());
+        return transaction;
+    }
+}


### PR DESCRIPTION
## ⭐️ Issue Number
- #115 

## 🚩 Summary
- 사용자 포인트 조회 API 구현 (GET /api/member/me/points)
- 포인트 거래 내역 조회 API 구현 (GET /api/member/me/point-transactions)
- 타입(EARNED/USED) 및 소스(GROUPBUY/REVIEW 등) 필터링 지원
- 페이징 처리 및 유효하지 않은 파라미터 예외 방지 처리
- 포인트 관련 DTO, 서비스, 컨트롤러, 테스트 코드 구현

## 🛠️ Technical Concerns
- PointTransactionRepository에 동적 쿼리 추가 (JPQL + IS NULL 조건 활용)
- 잘못된 enum 파라미터는 예외 발생 대신 'all'로 처리로 fallback 적용

## 🙂 To Reviewer
- 동적 쿼리 구현 방식(JPQL + IS NULL)이 적절한지 검토 요청
- 잘못된 파라미터를 'all'로 처리하는 로직이 적절한지 검토 요청
- 테스트 케이스 커버리지가 충분한지 검토 요청

## 📋 To Do
- [ ] 주문/배송 내역 구현
- [ ] 취소/반품 내역 구현
- [ ] 수동/자동 환불 구현

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 회원이 자신의 현재 포인트 잔액과 포인트 거래 내역(필터 및 페이지네이션 지원)을 조회할 수 있는 API가 추가되었습니다.

* **문서화**
  * 결제 관련 API의 Swagger 태그명이 한글 "결제"로 변경되었습니다.

* **테스트**
  * 포인트 서비스의 주요 기능(포인트 조회 및 거래 내역 조회)에 대한 단위 테스트가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->