### PR TITLE
Nginx 리버스 프록시 도입 및 ALB 연결 구성

### DIFF
--- a/docker/docker-compose-prod.yml
+++ b/docker/docker-compose-prod.yml
@@ -1,9 +1,22 @@
 version: "3.8"
 
 services:
+  nginx:
+    image: nginx:latest
+    container_name: ururu-nginx
+    restart: unless-stopped
+    ports:
+      - "80:80"
+      - "443:443"
+    volumes:
+      - ./nginx/nginx.conf:/etc/nginx/nginx.conf:ro
+    depends_on:
+      - springboot-app
+
   springboot-app:
     image: juwon0909/ururu:latest
     container_name: ururu
+    restart: unless-stopped
     ports:
       - "8080:8080"
     environment:


### PR DESCRIPTION
## ⭐️ Issue Number
- #134 

## 🚩 Summary
- `Nginx`를 리버스 프록시로 구성하여, 외부 요청을 SpringBoot 앱으로 전달하도록 설정
- `docker-compose-prod.yml`에 `nginx` 및 `springboot-app` 서비스 정의
- SpringBoot 앱은 `8080` 포트에서 실행되며, `nginx`는 `80`/`443` 포트로 외부 요청 수신

## 🛠️ Technical Concerns
- Nginx 설정은 `nginx.conf` 파일로 정의되며, `docker-compose`를 통해 `/etc/nginx/nginx.conf`에 마운트
- SpringBoot 컨테이너는 `SPRING_PROFILES_ACTIVE=prod` 환경변수 기반 실행
- `.env` 파일은 민감 정보 포함으로 GitHub 비공개 저장소 또는 직접 EC2 업로드 필요
- `restart: unless-stopped` 정책으로 EC2 재부팅 후 자동 재시작 보장

## 🙂 To Reviewer
- 이후 블루그린 배포를 위한 기반 구성입니다
- Nginx → SpringBoot 라우팅이 잘 되는지, `http://api.ururu.shop/health` 등으로 확인 부탁드립니다

## 📋 To Do
- [ ] 무중단 배포용 `blue/green` 컨테이너 이중 구성
- [ ] `nginx.conf.template` 및 `switch.sh` 도입
- [ ] GitHub Actions 배포 스크립트와 통합
- [ ] 헬스체크 및 롤백 로직 구성