### PR TITLE
HttpClient 빈 충돌 및 Docker Compose YAML 오류 해결 

### DIFF
--- a/docker/docker-compose-prod.yml
+++ b/docker/docker-compose-prod.yml
@@ -23,4 +23,3 @@ services:
       - SPRING_PROFILES_ACTIVE=prod
     env_file:
       - .env
-    restart: unless-stopped

--- a/src/main/java/com/ururulab/ururu/global/client/AiServiceClient.java
+++ b/src/main/java/com/ururulab/ururu/global/client/AiServiceClient.java
@@ -2,7 +2,6 @@ package com.ururulab.ururu.global.client;
 
 import com.ururulab.ururu.global.exception.BusinessException;
 import com.ururulab.ururu.global.exception.error.ErrorCode;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
@@ -23,10 +22,8 @@ import java.util.Map;
  */
 @Slf4j
 @Component
-@RequiredArgsConstructor
-public final class AiServiceClient {
+public class AiServiceClient {
 
-    @Qualifier("aiServiceRestClient")
     private final RestClient aiServiceRestClient;
 
     @Value("${ai.service.retry-count:3}")
@@ -34,6 +31,10 @@ public final class AiServiceClient {
 
     @Value("${ai.service.max-recommendations:50}")
     private int maxRecommendations;
+
+    public AiServiceClient(@Qualifier("aiServiceRestClient") final RestClient aiServiceRestClient) {
+        this.aiServiceRestClient = aiServiceRestClient;
+    }
 
     /**
      * AI 서비스 기본 헬스체크.

--- a/src/main/java/com/ururulab/ururu/global/config/HttpClientConfig.java
+++ b/src/main/java/com/ururulab/ururu/global/config/HttpClientConfig.java
@@ -9,6 +9,7 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
 import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
 import org.springframework.web.client.RestClient;
 import org.springframework.web.client.RestTemplate;
@@ -43,7 +44,8 @@ public class HttpClientConfig {
                 .build();
     }
 
-    @Bean
+    @Bean("httpClient")
+    @Primary
     public HttpClient httpClient(final PoolingHttpClientConnectionManager connectionManager,
                                  final RequestConfig requestConfig) {
         return HttpClientBuilder.create()
@@ -53,7 +55,7 @@ public class HttpClientConfig {
     }
 
     @Bean
-    public HttpComponentsClientHttpRequestFactory httpRequestFactory(final HttpClient httpClient) {
+    public HttpComponentsClientHttpRequestFactory httpRequestFactory(@Qualifier("httpClient") final HttpClient httpClient) {
         final HttpComponentsClientHttpRequestFactory factory = new HttpComponentsClientHttpRequestFactory();
         factory.setHttpClient(httpClient);
         return factory;


### PR DESCRIPTION
## ⭐️ Issue Number
- #137 

## 🚩 Summary
- HttpClientConfig에서 HttpClient 빈 충돌 문제 해결 (`@Primary` 어노테이션 추가)
- AiServiceClient의 CGLIB 프록시 생성 오류 해결 (생성자 주입 방식 변경)
- Docker Compose YAML 파일의 merge conflict로 인한 중복 키 오류 수정
- Spring Boot 애플리케이션 정상 시작 및 Docker Compose 실행 환경 복구

## 🛠️ Technical Concerns
- **HttpClient 빈 충돌**: `httpClient`와 `aiServiceHttpClient` 두 개의 빈이 존재하여 Spring이 어떤 빈을 주입할지 결정하지 못하는 문제
- **CGLIB 프록시 오류**: `@RequiredArgsConstructor` 사용 시 Spring AOP가 프록시 생성에 실패하는 문제
- **Docker Compose YAML 오류**: merge conflict 미처리로 인한 `restart` 키 중복으로 `yaml: unmarshal errors` 발생

## 🙂 To Reviewer
- HttpClientConfig의 `@Primary` 어노테이션과 `@Qualifier` 사용이 적절한지 검토 부탁드립니다
- AiServiceClient의 생성자 주입 방식 변경이 팀 컨벤션에 맞는지 확인 부탁드립니다
- Docker Compose 파일의 YAML 구조가 올바르게 수정되었는지 점검 부탁드립니다

## 📋 To Do
- [x] HttpClient 빈 충돌 해결 (`@Primary` 어노테이션 추가)
- [x] httpRequestFactory 메서드에 `@Qualifier` 명시적 지정
- [x] AiServiceClient 생성자 주입 방식으로 변경
- [x] Docker Compose YAML 파일의 중복 `restart` 키 제거
- [x] 컴파일 및 빌드 테스트 완료
- [x] Spring Boot 애플리케이션 정상 시작 확인