### PR TITLE
Access Token 만료 시간 수정

### DIFF
--- a/src/main/java/com/ururulab/ururu/auth/jwt/JwtCookieHelper.java
+++ b/src/main/java/com/ururulab/ururu/auth/jwt/JwtCookieHelper.java
@@ -32,7 +32,7 @@ public final class JwtCookieHelper {
     private final Environment environment;
 
     public void setAccessTokenCookie(final HttpServletResponse response, final String accessToken) {
-        final long maxAgeSeconds = jwtProperties.getAccessTokenExpiry() / 1000;
+        final long maxAgeSeconds = jwtProperties.getAccessTokenExpiry();
         setCookie(response, AuthConstants.ACCESS_TOKEN_COOKIE_NAME, accessToken, (int) maxAgeSeconds);
 
         log.debug("Access token cookie set with expiry: {} seconds for domain: {}",
@@ -40,7 +40,7 @@ public final class JwtCookieHelper {
     }
 
     public void setRefreshTokenCookie(final HttpServletResponse response, final String refreshToken) {
-        final long maxAgeSeconds = jwtProperties.getRefreshTokenExpiry() / 1000;
+        final long maxAgeSeconds = jwtProperties.getRefreshTokenExpiry();
         setCookie(response, AuthConstants.REFRESH_TOKEN_COOKIE_NAME, refreshToken, (int) maxAgeSeconds);
 
         log.debug("Refresh token cookie set with expiry: {} seconds for domain: {}",

--- a/src/main/java/com/ururulab/ururu/auth/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/ururulab/ururu/auth/jwt/JwtTokenProvider.java
@@ -152,7 +152,7 @@ public final class JwtTokenProvider {
     private String createToken(final Long userId, final String email, final String role, final String userType,
                                final TokenType type, final long expirySeconds) {
         final Date now = new Date();
-        final Date expiry = new Date(now.getTime() + expirySeconds);
+        final Date expiry = new Date(now.getTime() + (expirySeconds * 1000));
 
         final JwtBuilder builder = Jwts.builder()
                 .subject(userId.toString())

--- a/src/main/java/com/ururulab/ururu/auth/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/ururulab/ururu/auth/jwt/JwtTokenProvider.java
@@ -152,7 +152,7 @@ public final class JwtTokenProvider {
     private String createToken(final Long userId, final String email, final String role, final String userType,
                                final TokenType type, final long expirySeconds) {
         final Date now = new Date();
-        final Date expiry = new Date(now.getTime() + expirySeconds * 1000);
+        final Date expiry = new Date(now.getTime() + expirySeconds);
 
         final JwtBuilder builder = Jwts.builder()
                 .subject(userId.toString())


### PR DESCRIPTION
## ⭐️ Issue Number
- #154 

## 🚩 Summary

- JWT 토큰 만료 시간 계산 로직 수정
- 액세스 토큰 만료 시간이 3초에서 1시간(3600초)으로 올바르게 설정되도록 수정
- 리프레시 토큰 만료 시간이 14일(1209600초)로 올바르게 설정되도록 수정

## 🛠️ Technical Concerns

- 문제점: JwtTokenProvider.createToken() 메서드에서 expirySeconds를 밀리초 단위로 계산할 때 초 단위를 밀리초 단위로 변환하지 않아서 토큰이 매우 짧은 시간(3초)에 만료되는 문제 발생
- 해결방법: expirySeconds * 1000을 추가하여 초 단위를 밀리초 단위로 올바르게 변환 (Date는 밀리초)
- 영향 범위: 모든 JWT 토큰 생성 (액세스 토큰, 리프레시 토큰)

## 🙂 To Reviewer
JWT 토큰 만료 시간 계산 로직을 수정했습니다.
설정 파일의 값(3600초, 1209600초)과 실제 토큰 만료 시간이 일치하도록 수정했습니다.

## 📋 To Do

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 인증 토큰 쿠키의 만료 시간이 올바르게 적용되도록 수정되었습니다.  
* **스타일**
  * 토큰 만료 시간 계산식의 가독성이 향상되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->