### PR TITLE
공동구매 조회 관련 판매자 전용 API 개발 및 카테고리, 태그 API 개발 

### DIFF
--- a/src/main/java/com/ururulab/ururu/global/config/SecurityConfig.java
+++ b/src/main/java/com/ururulab/ururu/global/config/SecurityConfig.java
@@ -46,6 +46,8 @@ public class SecurityConfig {
                         .requestMatchers("/api/public/**").permitAll()
                         .requestMatchers("/api/sellers/signup").permitAll()
                         .requestMatchers("/api/sellers/check/**").permitAll()
+                        .requestMatchers("/products/**").permitAll() // 추후 삭제
+                        .requestMatchers("/groupbuy/**").permitAll() // 추후 삭제
                         .requestMatchers("/health").permitAll()
                         .requestMatchers("/swagger-ui/**", "/v3/api-docs/**").permitAll()
                         .requestMatchers("/h2-console/**").permitAll()

--- a/src/main/java/com/ururulab/ururu/global/config/SecurityConfig.java
+++ b/src/main/java/com/ururulab/ururu/global/config/SecurityConfig.java
@@ -46,8 +46,6 @@ public class SecurityConfig {
                         .requestMatchers("/api/public/**").permitAll()
                         .requestMatchers("/api/sellers/signup").permitAll()
                         .requestMatchers("/api/sellers/check/**").permitAll()
-                        .requestMatchers("/products/**").permitAll() // 추후 삭제
-                        .requestMatchers("/groupbuy/**").permitAll() // 추후 삭제
                         .requestMatchers("/health").permitAll()
                         .requestMatchers("/swagger-ui/**", "/v3/api-docs/**").permitAll()
                         .requestMatchers("/h2-console/**").permitAll()

--- a/src/main/java/com/ururulab/ururu/global/domain/repository/TagCategoryRepository.java
+++ b/src/main/java/com/ururulab/ururu/global/domain/repository/TagCategoryRepository.java
@@ -4,6 +4,9 @@ import com.ururulab.ururu.global.domain.entity.TagCategory;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface TagCategoryRepository extends JpaRepository<TagCategory, Long> {
+    List<TagCategory> findAllByIsActiveTrueOrderByDisplayOrder();
 }

--- a/src/main/java/com/ururulab/ururu/global/exception/error/ErrorCode.java
+++ b/src/main/java/com/ururulab/ururu/global/exception/error/ErrorCode.java
@@ -118,7 +118,11 @@ public enum ErrorCode {
 	DISCOUNT_STAGE_RATE_ORDER_INVALID(HttpStatus.BAD_REQUEST, "GROUPBUY032", "할인 단계의 할인률이 순서대로 입력되지 않았습니다."),
 	GROUPBUY_DELETE_NOT_ALLOWED(HttpStatus.BAD_REQUEST, "GROUPBUY033", "DRAFT 상태인 공동구매만 삭제할 수 있습니다."),
 	INVALID_SEARCH_KEYWORD(HttpStatus.BAD_REQUEST, "GROUPBUY034", "유효하지 않은 검색어입니다."),
+	GROUPBUY_EMPTY(HttpStatus.NOT_FOUND, "GROUPBUY035", "판매자의 공동구매가 존재하지 않습니다."),
 
+	// -- 커서 --
+	CURSOR_ENCODING_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "CURSOR001", "커서 인코딩에 실패했습니다"),
+	CURSOR_DECODING_FAILED(HttpStatus.BAD_REQUEST, "CURSOR002", "커서 디코딩에 실패했습니다: %s"),
 
 	// --- 공동구매 통계 ---
 	GROUPBUY_STATISTICS_ALREADY_EXISTS(HttpStatus.CONFLICT, "GB_STAT_001", "이미 해당 공동구매의 통계가 존재합니다."),

--- a/src/main/java/com/ururulab/ururu/groupBuy/controller/GroupBuyController.java
+++ b/src/main/java/com/ururulab/ururu/groupBuy/controller/GroupBuyController.java
@@ -1,10 +1,13 @@
 package com.ururulab.ururu.groupBuy.controller;
 
 import com.ururulab.ururu.global.domain.dto.ApiResponseFormat;
+import com.ururulab.ururu.global.exception.BusinessException;
+import com.ururulab.ururu.global.exception.error.ErrorCode;
 import com.ururulab.ururu.groupBuy.dto.request.GroupBuyRequest;
 import com.ururulab.ururu.groupBuy.dto.request.GroupBuyStatusUpdateRequest;
 import com.ururulab.ururu.groupBuy.dto.response.*;
 import com.ururulab.ururu.groupBuy.service.*;
+import com.ururulab.ururu.groupBuy.util.AuthUtils;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -15,9 +18,13 @@ import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -36,6 +43,7 @@ public class GroupBuyController {
     private final GroupBuyListService groupBuyListService;
     private final GroupBuyProductService groupBuyProductService;
     private final GroupBuyDeleteService groupBuyDeleteService;
+    private final GroupBuySellerListService groupBuySellerListService;
 
     @Operation(summary = "공동구매 등록", description = "판매자가 새로운 공동구매를 등록합니다.")
     @ApiResponses({
@@ -53,16 +61,16 @@ public class GroupBuyController {
             @ApiResponse(responseCode = "409", description = "중복된 공동구매가 존재합니다."),
             @ApiResponse(responseCode = "500", description = "서버 내부 오류")
     })
+    //TODO {sellerId} 제거하기
     @PostMapping(value = "/{sellerId}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<ApiResponseFormat<GroupBuyCreateResponse>> createGroupBuy(
             @PathVariable Long sellerId,
-            // @AuthenticationPrincipal CustomUserDetails userDetails, // JWT 인증 구현 후 주석 제거
             @Valid @RequestPart("request") GroupBuyRequest groupBuyRequest,
             @RequestPart(value = "thumbnail", required = false) MultipartFile thumbnail,
             @RequestPart(value = "detailImages", required = false) List<MultipartFile> detailImages
     ) {
-        // JWT 인증 구현 후 sellerId 추출 로직
-        // Long sellerId = userDetails.getSellerId();
+        //TODO @PathVariable Long sellerId 삭제 후 주석 해제
+        //Long sellerId = AuthUtils.getSellerIdFromAuthentication();
 
         GroupBuyCreateResponse response = groupBuyService.createGroupBuy(groupBuyRequest, sellerId, thumbnail, detailImages);
         return ResponseEntity.status(HttpStatus.CREATED)
@@ -100,14 +108,45 @@ public class GroupBuyController {
             @ApiResponse(responseCode = "404", description = "존재하지 않는 판매자입니다."),
             @ApiResponse(responseCode = "500", description = "서버 내부 오류")
     })
-    @GetMapping("/{sellerId}/{groupBuyId}")
+    //TODO {sellerId} 제거하기
+    @GetMapping("/seller/{sellerId}/{groupBuyId}")
     public ResponseEntity<ApiResponseFormat<GroupBuyDetailResponse>> getSellerGroupBuyDetail(
             @PathVariable Long sellerId,
             @PathVariable Long groupBuyId
     ) {
 
+        //TODO @PathVariable Long sellerId 삭제 후 주석 해제
+        //Long sellerId = AuthUtils.getSellerIdFromAuthentication();
+
         GroupBuyDetailResponse response = groupBuyDetailService.getSellerGroupBuyDetail(sellerId, groupBuyId);
         return ResponseEntity.ok(ApiResponseFormat.success("공동구매 상세 정보를 성공적으로 조회했습니다.", response));
+    }
+
+    @Operation(
+            summary = "판매자용 공동구매 목록 조회",
+            description = "판매자가 자신의 모든 공동구매 목록을 조회합니다. DRAFT, OPEN, CLOSED 상태를 모두 포함하며 상태별 필터링과 페이지네이션을 지원합니다."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "판매자 공동구매 목록 조회 성공"),
+            @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자"),
+            @ApiResponse(responseCode = "403", description = "판매자 권한이 없음"),
+            @ApiResponse(responseCode = "404", description = "존재하지 않는 판매자"),
+            @ApiResponse(responseCode = "500", description = "서버 내부 오류")
+    })
+    //TODO {sellerId} 제거하기
+    @GetMapping("/seller/{sellerId}")
+    public ResponseEntity<ApiResponseFormat<Page<GroupBuySellerListResponse>>> getSellerGroupBuyList(
+            @PathVariable Long sellerId,
+            Pageable pageable
+    ) {
+        //TODO @PathVariable Long sellerId 삭제 후 주석 해제
+        //Long sellerId = AuthUtils.getSellerIdFromAuthentication();
+
+        Page<GroupBuySellerListResponse> response = groupBuySellerListService.getSellerGroupBuyList(sellerId, pageable);
+
+        return ResponseEntity.ok(
+                ApiResponseFormat.success("판매자 공동구매 목록 조회에 성공하였습니다.", response)
+        );
     }
 
     @Operation(
@@ -123,11 +162,15 @@ public class GroupBuyController {
                     - 현재 상태에서 요청한 상태로 변경할 수 없습니다.
                     """)
     })
+    //TODO {sellerId} 제거하기
     @PatchMapping("/{sellerId}/{groupBuyId}/status")
     public ResponseEntity<ApiResponseFormat<Void>> updateGroupBuyStatus(
             @PathVariable Long sellerId,
             @PathVariable Long groupBuyId,
             @Valid @RequestBody GroupBuyStatusUpdateRequest request) {
+
+        //TODO @PathVariable Long sellerId 삭제 후 주석 해제
+        //Long sellerId = AuthUtils.getSellerIdFromAuthentication();
 
         // 상태 업데이트 (DRAFT → OPEN)
         updateGroupBuyStatusService.updateGroupBuyStatus(sellerId, groupBuyId, request);
@@ -162,10 +205,14 @@ public class GroupBuyController {
 
     @Operation(summary = "공동구매 등록 페이지 데이터",
             description = "공동구매 등록 시 필요한 판매자의 상품과 옵션 정보를 조회합니다.")
+    //TODO {sellerId} 제거하기
     @GetMapping("/{sellerId}/create")
     public ResponseEntity<ApiResponseFormat<GroupBuyCreatePageResponse>> getGroupBuyCreateData(
             @Parameter(description = "판매자 ID", example = "1")
             @PathVariable Long sellerId) {
+
+        //TODO @PathVariable Long sellerId 삭제 후 주석 해제
+        //Long sellerId = AuthUtils.getSellerIdFromAuthentication();
 
         GroupBuyCreatePageResponse response = groupBuyProductService.getGroupBuyCreateData(sellerId);
         return ResponseEntity.ok(ApiResponseFormat.success("공동구매 등록 페이지 데이터를 성공적으로 조회했습니다.", response));
@@ -182,11 +229,16 @@ public class GroupBuyController {
             @ApiResponse(responseCode = "404", description = "해당 공동구매를 찾을 수 없습니다."),
             @ApiResponse(responseCode = "500", description = "서버 내부 오류")
     })
+    //TODO {sellerId} 제거하기
     @DeleteMapping("/{sellerId}/{groupBuyId}")
     public ResponseEntity<ApiResponseFormat<Void>> deleteGroupBuy(
             @PathVariable Long groupBuyId,
             @PathVariable Long sellerId
     ) {
+
+        //TODO @PathVariable Long sellerId 삭제 후 주석 해제
+        //Long sellerId = AuthUtils.getSellerIdFromAuthentication();
+
         groupBuyDeleteService.deleteGroupBuy(groupBuyId, sellerId);
         return ResponseEntity.ok(ApiResponseFormat.success("공동구매가 성공적으로 삭제되었습니다."));
     }

--- a/src/main/java/com/ururulab/ururu/groupBuy/controller/GroupBuyStatisticsController.java
+++ b/src/main/java/com/ururulab/ururu/groupBuy/controller/GroupBuyStatisticsController.java
@@ -9,7 +9,6 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -42,6 +41,10 @@ public class GroupBuyStatisticsController {
             @PathVariable Long groupBuyId,
             @PathVariable Long sellerId
     ) {
+
+        //TODO @PathVariable Long sellerId 삭제 후 주석 해제
+        //Long sellerId = AuthUtils.getSellerIdFromAuthentication();
+
         GroupBuyStatisticsDetailResponse response = groupBuyStatisticsService.getGroupBuyStatisticsDetail(groupBuyId, sellerId);
         return ResponseEntity.ok(ApiResponseFormat.success("공동구매 상세 통계 조회에 성공하였습니다.", response));
     }
@@ -59,6 +62,9 @@ public class GroupBuyStatisticsController {
     public ResponseEntity<ApiResponseFormat<List<GroupBuyStatisticsResponse>>> getMyGroupBuyStatistics(
             @PathVariable Long sellerId
     ) {
+        //TODO @PathVariable Long sellerId 삭제 후 주석 해제
+        //Long sellerId = AuthUtils.getSellerIdFromAuthentication();
+
         List<GroupBuyStatisticsResponse> response = groupBuyStatisticsService.getGroupBuyStatisticsBySeller(sellerId);
         return ResponseEntity.ok(ApiResponseFormat.success("공동구매 통계 목록 조회에 성공하였습니다.", response));
     }

--- a/src/main/java/com/ururulab/ururu/groupBuy/domain/repository/GroupBuyRepository.java
+++ b/src/main/java/com/ururulab/ururu/groupBuy/domain/repository/GroupBuyRepository.java
@@ -2,6 +2,8 @@ package com.ururulab.ururu.groupBuy.domain.repository;
 
 import com.ururulab.ururu.groupBuy.domain.entity.GroupBuy;
 import com.ururulab.ururu.groupBuy.domain.entity.enumerated.GroupBuyStatus;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -94,4 +96,11 @@ public interface GroupBuyRepository extends JpaRepository<GroupBuy, Long>, Group
           AND gb.endsAt > CURRENT_TIMESTAMP
         """)
     List<GroupBuy> findAllPublicWithOptions();
+
+
+    @Query("SELECT gb FROM GroupBuy gb WHERE gb.seller.id = :sellerId ORDER BY gb.createdAt DESC")
+    Page<GroupBuy> findBySellerIdWithPagination(@Param("sellerId") Long sellerId, Pageable pageable);
+
+    @Query("SELECT gb FROM GroupBuy gb JOIN FETCH gb.options WHERE gb.id IN :groupBuyIds")
+    List<GroupBuy> findByIdsWithOptions(@Param("groupBuyIds") List<Long> groupBuyIds);
 }

--- a/src/main/java/com/ururulab/ururu/groupBuy/dto/response/GroupBuySellerListResponse.java
+++ b/src/main/java/com/ururulab/ururu/groupBuy/dto/response/GroupBuySellerListResponse.java
@@ -1,0 +1,60 @@
+package com.ururulab.ururu.groupBuy.dto.response;
+
+import com.ururulab.ururu.groupBuy.domain.entity.GroupBuy;
+import com.ururulab.ururu.groupBuy.domain.entity.GroupBuyOption;
+import com.ururulab.ururu.groupBuy.domain.entity.enumerated.GroupBuyStatus;
+
+import java.time.Instant;
+import java.util.List;
+
+public record GroupBuySellerListResponse(
+        Long id,
+        String title,
+        String thumbnailUrl,
+        Integer displayFinalPrice,
+        Integer startPrice,
+        Integer maxDiscountRate,
+        GroupBuyStatus status,
+        Instant startAt,
+        Instant endsAt,
+        Integer totalStock,
+        Integer soldQuantity,
+        Integer orderCount,
+        Instant createdAt,
+        Instant updatedAt
+) {
+    public static GroupBuySellerListResponse from(GroupBuy groupBuy,
+                                                  List<GroupBuyOption> options,
+                                                  Integer orderCount) {
+
+        Integer startPrice = options.stream()
+                .map(GroupBuyOption::getPriceOverride)
+                .min(Integer::compareTo)
+                .orElse(0);
+
+        Integer totalStock = options.stream()
+                .mapToInt(GroupBuyOption::getInitialStock)
+                .sum();
+
+        Integer soldQuantity = options.stream()
+                .mapToInt(GroupBuyOption::getSoldQuantity)
+                .sum();
+
+        return new GroupBuySellerListResponse(
+                groupBuy.getId(),
+                groupBuy.getTitle(),
+                groupBuy.getThumbnailUrl(),
+                groupBuy.getDisplayFinalPrice(),
+                startPrice,
+                groupBuy.getMaxDiscountRate(),
+                groupBuy.getStatus(),
+                groupBuy.getStartAt(),
+                groupBuy.getEndsAt(),
+                totalStock,
+                soldQuantity,
+                orderCount,
+                groupBuy.getCreatedAt(),
+                groupBuy.getUpdatedAt()
+        );
+    }
+}

--- a/src/main/java/com/ururulab/ururu/groupBuy/service/GroupBuyListService.java
+++ b/src/main/java/com/ururulab/ururu/groupBuy/service/GroupBuyListService.java
@@ -19,8 +19,7 @@ import java.util.Base64;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import static com.ururulab.ururu.global.exception.error.ErrorCode.GROUPBUY_NOT_FOUND;
-import static com.ururulab.ururu.global.exception.error.ErrorCode.INVALID_SEARCH_KEYWORD;
+import static com.ururulab.ururu.global.exception.error.ErrorCode.*;
 
 @Service
 @Slf4j
@@ -173,7 +172,7 @@ public class GroupBuyListService {
             return Base64.getEncoder().encodeToString(json.getBytes());
         } catch (Exception e) {
             log.error("Failed to encode cursor", e);
-            throw new BusinessException(GROUPBUY_NOT_FOUND, "커서 인코딩에 실패했습니다.");
+            throw new BusinessException(CURSOR_ENCODING_FAILED);
         }
     }
 
@@ -189,7 +188,7 @@ public class GroupBuyListService {
             return objectMapper.readValue(json, CursorInfoDto.class);
         } catch (Exception e) {
             log.error("Failed to decode cursor: {}", cursor, e);
-            throw new BusinessException(GROUPBUY_NOT_FOUND, "유효하지 않은 커서입니다.");
+            throw new BusinessException(CURSOR_DECODING_FAILED);
         }
     }
 

--- a/src/main/java/com/ururulab/ururu/groupBuy/service/GroupBuyProductService.java
+++ b/src/main/java/com/ururulab/ururu/groupBuy/service/GroupBuyProductService.java
@@ -21,7 +21,7 @@ public class GroupBuyProductService {
 
     public GroupBuyCreatePageResponse getGroupBuyCreateData(Long sellerId) {
 
-        // 해당 판매자의 활성화된 상품과 옵션을 함께 조회
+        // 해당 판매자의 공동구매에 사용 안 된 상품과 옵션을 함께 조회
         List<Product> products = productRepository.findBySellerIdAndStatusWithOptions(sellerId, Status.INACTIVE);
 
         if (products == null || products.isEmpty()) {

--- a/src/main/java/com/ururulab/ururu/groupBuy/service/GroupBuySellerListService.java
+++ b/src/main/java/com/ururulab/ururu/groupBuy/service/GroupBuySellerListService.java
@@ -1,0 +1,63 @@
+package com.ururulab.ururu.groupBuy.service;
+
+import com.ururulab.ururu.global.exception.BusinessException;
+import com.ururulab.ururu.global.exception.error.ErrorCode;
+import com.ururulab.ururu.groupBuy.domain.entity.GroupBuy;
+import com.ururulab.ururu.groupBuy.domain.entity.GroupBuyOption;
+import com.ururulab.ururu.groupBuy.domain.repository.GroupBuyOptionRepository;
+import com.ururulab.ururu.groupBuy.domain.repository.GroupBuyRepository;
+import com.ururulab.ururu.groupBuy.dto.response.GroupBuySellerListResponse;
+import com.ururulab.ururu.seller.domain.entity.Seller;
+import com.ururulab.ururu.seller.domain.repository.SellerRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+import static com.ururulab.ururu.global.exception.error.ErrorCode.*;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class GroupBuySellerListService {
+
+    private final GroupBuyRepository groupBuyRepository;
+    private final SellerRepository sellerRepository;
+
+    public Page<GroupBuySellerListResponse> getSellerGroupBuyList(Long sellerId, Pageable pageable) {
+        // 본인 인증 확인
+        Seller seller = sellerRepository.findById(sellerId)
+                .orElseThrow(() -> new BusinessException(SELLER_NOT_FOUND));
+
+        Page<GroupBuy> groupBuyPage = groupBuyRepository.findBySellerIdWithPagination(sellerId, pageable);
+
+        if (groupBuyPage.isEmpty()) {
+            throw new BusinessException(GROUPBUY_EMPTY);
+        }
+
+        // 2. 해당 페이지의 GroupBuy들과 Options를 JOIN FETCH로 조회
+        List<Long> groupBuyIds = groupBuyPage.getContent().stream()
+                .map(GroupBuy::getId)
+                .toList();
+
+        List<GroupBuy> groupBuysWithOptions = groupBuyRepository.findByIdsWithOptions(groupBuyIds);
+
+        List<GroupBuySellerListResponse> responses = groupBuysWithOptions.stream()
+                .map(groupBuy -> {
+                    List<GroupBuyOption> options = groupBuy.getOptions();
+                    Integer orderCount = options.stream()
+                            .mapToInt(GroupBuyOption::getSoldQuantity)
+                            .sum();
+                    return GroupBuySellerListResponse.from(groupBuy, options, orderCount);
+                })
+                .toList();
+
+        return new PageImpl<>(responses, pageable, groupBuyPage.getTotalElements());
+    }
+}

--- a/src/main/java/com/ururulab/ururu/groupBuy/util/AuthUtils.java
+++ b/src/main/java/com/ururulab/ururu/groupBuy/util/AuthUtils.java
@@ -1,0 +1,37 @@
+package com.ururulab.ururu.groupBuy.util;
+
+import com.ururulab.ururu.global.exception.BusinessException;
+import com.ururulab.ururu.global.exception.error.ErrorCode;
+import lombok.experimental.UtilityClass;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+@UtilityClass
+public class AuthUtils {
+
+    /**
+     * JWT 토큰에서 판매자 ID를 추출하는 헬퍼 메서드
+     */
+    public Long getSellerIdFromAuthentication() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+        if (authentication == null || !authentication.isAuthenticated()) {
+            throw new BusinessException(ErrorCode.INVALID_JWT_TOKEN);
+        }
+
+        Object principal = authentication.getPrincipal();
+        if (!(principal instanceof Long)) {
+            throw new BusinessException(ErrorCode.MALFORMED_JWT_TOKEN);
+        }
+
+        // 판매자 권한 확인
+        boolean isSeller = authentication.getAuthorities().stream()
+                .anyMatch(authority -> "ROLE_SELLER".equals(authority.getAuthority()));
+
+        if (!isSeller) {
+            throw new BusinessException(ErrorCode.ACCESS_DENIED);
+        }
+
+        return (Long) principal;
+    }
+}

--- a/src/main/java/com/ururulab/ururu/product/controller/ProductMetadataController.java
+++ b/src/main/java/com/ururulab/ururu/product/controller/ProductMetadataController.java
@@ -1,0 +1,39 @@
+package com.ururulab.ururu.product.controller;
+
+import com.ururulab.ururu.global.domain.dto.ApiResponseFormat;
+import com.ururulab.ururu.product.dto.response.ProductMetadataResponse;
+import com.ururulab.ururu.product.service.ProductMetadataService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/products/create")
+public class ProductMetadataController {
+
+    private final ProductMetadataService productMetadataService;
+
+    @Operation(
+            summary = "상품 등록 메타데이터 조회",
+            description = "카테고리 트리와 태그 리스트를 함께 반환합니다. 프론트에서 상품 등록/수정 시 사용합니다."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "상품 메타데이터 조회 성공"),
+            @ApiResponse(responseCode = "404", description = "카테고리 또는 태그 데이터가 없습니다."),
+            @ApiResponse(responseCode = "500", description = "서버 내부 오류")
+    })
+    @GetMapping
+    public ResponseEntity<ApiResponseFormat<ProductMetadataResponse>> getMetadata() {
+        ProductMetadataResponse metadata = productMetadataService.getMetadata();
+
+        return ResponseEntity.ok(
+                ApiResponseFormat.success("상품 메타데이터 조회가 성공했습니다.", metadata)
+        );
+    }
+}

--- a/src/main/java/com/ururulab/ururu/product/dto/common/CategoryTreeDto.java
+++ b/src/main/java/com/ururulab/ururu/product/dto/common/CategoryTreeDto.java
@@ -1,0 +1,10 @@
+package com.ururulab.ururu.product.dto.common;
+
+import java.util.List;
+
+public record CategoryTreeDto(
+        Long value,
+        String label,
+        List<CategoryTreeDto> children
+) {
+}

--- a/src/main/java/com/ururulab/ururu/product/dto/common/TagDto.java
+++ b/src/main/java/com/ururulab/ururu/product/dto/common/TagDto.java
@@ -1,0 +1,7 @@
+package com.ururulab.ururu.product.dto.common;
+
+public record TagDto(
+        Long value,
+        String label
+) {
+}

--- a/src/main/java/com/ururulab/ururu/product/dto/response/ProductMetadataResponse.java
+++ b/src/main/java/com/ururulab/ururu/product/dto/response/ProductMetadataResponse.java
@@ -1,0 +1,12 @@
+package com.ururulab.ururu.product.dto.response;
+
+import com.ururulab.ururu.product.dto.common.CategoryTreeDto;
+import com.ururulab.ururu.product.dto.common.TagDto;
+
+import java.util.List;
+
+public record ProductMetadataResponse(
+        List<CategoryTreeDto> categories,
+        List<TagDto> tags
+) {
+}

--- a/src/main/java/com/ururulab/ururu/product/service/ProductMetadataService.java
+++ b/src/main/java/com/ururulab/ururu/product/service/ProductMetadataService.java
@@ -1,0 +1,69 @@
+package com.ururulab.ururu.product.service;
+
+import com.ururulab.ururu.global.domain.entity.TagCategory;
+import com.ururulab.ururu.global.domain.repository.TagCategoryRepository;
+import com.ururulab.ururu.global.exception.BusinessException;
+import com.ururulab.ururu.product.domain.entity.Category;
+import com.ururulab.ururu.product.domain.repository.CategoryRepository;
+import com.ururulab.ururu.product.dto.common.CategoryTreeDto;
+import com.ururulab.ururu.product.dto.response.ProductMetadataResponse;
+import com.ururulab.ururu.product.dto.common.TagDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import static com.ururulab.ururu.global.exception.error.ErrorCode.*;
+
+@Service
+@RequiredArgsConstructor
+public class ProductMetadataService {
+
+    private final CategoryRepository categoryRepository;
+    private final TagCategoryRepository tagCategoryRepository;
+
+    public ProductMetadataResponse getMetadata() {
+        List<Category> categories = categoryRepository.findAll();
+        List<TagCategory> tags = tagCategoryRepository.findAllByIsActiveTrueOrderByDisplayOrder();
+
+        if (categories == null || categories.isEmpty()) {
+            throw new BusinessException(CATEGORY_NOT_FOUND); // 직접 정의한 에러코드
+        }
+
+        if (tags == null || tags.isEmpty()) {
+            throw new BusinessException(TAG_NOT_FOUND); // 직접 정의한 에러코드
+        }
+
+        List<CategoryTreeDto> categoryTree = buildCategoryTree(categories);
+        List<TagDto> tagDtos = tags.stream()
+                .map(tag -> new TagDto(tag.getId(), tag.getName()))
+                .toList();
+
+        return new ProductMetadataResponse(categoryTree, tagDtos);
+    }
+
+    private List<CategoryTreeDto> buildCategoryTree(List<Category> categories) {
+        Map<Long, List<Category>> grouped = categories.stream()
+                .filter(c -> c.getParentId() != null)
+                .collect(Collectors.groupingBy(Category::getParentId));
+
+        return categories.stream()
+                .filter(c -> c.getParentId() == null)
+                .map(c -> toTreeDto(c, grouped))
+                .toList();
+    }
+
+    private CategoryTreeDto toTreeDto(Category category, Map<Long, List<Category>> group) {
+        List<CategoryTreeDto> children = Optional.ofNullable(group.get(category.getId()))
+                .orElse(List.of())
+                .stream()
+                .map(child -> toTreeDto(child, group))
+                .toList();
+
+        return new CategoryTreeDto(category.getId(), category.getName(), children);
+    }
+}


### PR DESCRIPTION
## ⭐️ Issue Number
- #150 

## 🚩 Summary
- 공동구매 조회 관련 판매자 전용 공동구매 목록 조회 API 개발(Draft까지 포함)
- 판매자 전용 상품 목록 조회와 통일성을 위해 페이지네이션으로 구현
- 상품 등록, 수정 시 카테고리/태그 데이터 응답을 위한 API 개발
- sellerId 추출을 위한 AuthUtils 클래스 구현

## 🛠️ Technical Concerns


## 🙂 To Reviewer
판매자 전용 공동구매 목록 조회가 적절하게 구현 되었고 페이지네이션이 잘 적용되었는지와 카테고리/태그 데이터 응답에 대한 API가 적절하게 구현 되었는지 확인 부탁드립니다! 먼저 코드래빗과 싸우고 있겠습니다

## 📋 To Do
프론트엔드 API 연동 작업
공동구매 수정 작업 (DRAFT 시에만)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 판매자별 공동구매 목록을 페이지네이션 형태로 조회할 수 있는 엔드포인트가 추가되었습니다.
  * 상품 등록 시 사용할 수 있는 카테고리 트리 및 태그 목록을 제공하는 상품 메타데이터 조회 기능이 추가되었습니다.

* **버그 수정**
  * 커서 인코딩/디코딩 오류 및 판매자 공동구매 미존재 상황에 대한 에러 코드가 추가되어, 오류 메시지가 더 명확하게 제공됩니다.

* **기타**
  * 인증 정보를 통한 판매자 식별 유틸리티가 추가되었습니다.
  * 카테고리 및 태그 정보를 위한 데이터 구조가 도입되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->