### PR TITLE
수동 환불 요청 및 처리 API 구현

### DIFF
--- a/src/main/java/com/ururulab/ururu/global/exception/error/ErrorCode.java
+++ b/src/main/java/com/ururulab/ururu/global/exception/error/ErrorCode.java
@@ -57,6 +57,12 @@ public enum ErrorCode {
 	INVALID_JSON(HttpStatus.BAD_REQUEST, "WEBHOOK002", "웹훅 데이터 형식이 올바르지 않습니다"),
 	WEBHOOK_PROCESSING_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "WEBHOOK003", "웹훅 처리 중 오류가 발생했습니다"),
 
+	// --- 환불 ---
+	REFUND_NOT_FOUND(HttpStatus.NOT_FOUND, "REFUND001", "존재하지 않는 환불입니다."),
+	REFUND_ALREADY_PROCESSED(HttpStatus.CONFLICT, "REFUND002", "이미 처리된 환불입니다."),
+	REFUND_PERIOD_EXPIRED(HttpStatus.BAD_REQUEST, "REFUND003", "환불 처리 기간이 만료되었습니다. (%d일 이내)"),
+	DUPLICATE_REFUND_REQUEST(HttpStatus.CONFLICT, "REFUND004", "이미 진행 중인 환불 요청이 있습니다."),
+
 	// --- 인증 ---
 	INVALID_JWT_TOKEN(HttpStatus.UNAUTHORIZED, "AUTH001", "유효하지 않은 토큰입니다."),
 	INVALID_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "AUTH002", "유효하지 않은 리프레시 토큰입니다."),

--- a/src/main/java/com/ururulab/ururu/global/exception/error/ErrorCode.java
+++ b/src/main/java/com/ururulab/ururu/global/exception/error/ErrorCode.java
@@ -62,6 +62,7 @@ public enum ErrorCode {
 	REFUND_ALREADY_PROCESSED(HttpStatus.CONFLICT, "REFUND002", "이미 처리된 환불입니다."),
 	REFUND_PERIOD_EXPIRED(HttpStatus.BAD_REQUEST, "REFUND003", "환불 처리 기간이 만료되었습니다. (%d일 이내)"),
 	DUPLICATE_REFUND_REQUEST(HttpStatus.CONFLICT, "REFUND004", "이미 진행 중인 환불 요청이 있습니다."),
+	INVALID_REFUND_ACTION(HttpStatus.BAD_REQUEST, "REFUND005", "유효하지 않은 환불 처리 액션입니다."),
 
 	// --- 인증 ---
 	INVALID_JWT_TOKEN(HttpStatus.UNAUTHORIZED, "AUTH001", "유효하지 않은 토큰입니다."),

--- a/src/main/java/com/ururulab/ururu/groupBuy/domain/repository/GroupBuyOptionRepository.java
+++ b/src/main/java/com/ururulab/ururu/groupBuy/domain/repository/GroupBuyOptionRepository.java
@@ -30,6 +30,15 @@ public interface GroupBuyOptionRepository extends JpaRepository<GroupBuyOption, 
     Optional<GroupBuyOption> findByIdWithDetails(@Param("optionId") Long optionId);
 
     /**
+     * 공구 옵션 재고 증가
+     * 환불 승인 시 재고 복구용
+     */
+    @Modifying
+    @Query("UPDATE GroupBuyOption gbo SET gbo.stock = gbo.stock + :quantity " +
+            "WHERE gbo.id = :optionId")
+    int increaseStock(@Param("optionId") Long optionId, @Param("quantity") Integer quantity);
+
+    /**
      * 공구 옵션 재고 차감
      * Payment 도메인에서 결제 완료 시 사용:
      * - 결제 승인 완료 후 실제 재고 차감

--- a/src/main/java/com/ururulab/ururu/member/domain/repository/MemberRepository.java
+++ b/src/main/java/com/ururulab/ururu/member/domain/repository/MemberRepository.java
@@ -49,6 +49,6 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
      */
     @Modifying
     @Query("UPDATE Member m SET m.point = m.point + :amount WHERE m.id = :memberId")
-    void increasePoints(@Param("memberId") Long memberId, @Param("amount") Integer amount);
+    int increasePoints(@Param("memberId") Long memberId, @Param("amount") Integer amount);
 
 }

--- a/src/main/java/com/ururulab/ururu/order/domain/entity/Order.java
+++ b/src/main/java/com/ururulab/ururu/order/domain/entity/Order.java
@@ -10,6 +10,7 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
@@ -46,6 +47,9 @@ public class Order extends BaseEntity {
 
     @Column(length = OrderPolicy.TRACKING_NUMBER_MAX_LENGTH)
     private String trackingNumber;
+
+    @Column
+    private Instant trackingRegisteredAt;
 
     @OneToMany(mappedBy = "order", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<OrderItem> orderItems = new ArrayList<>();
@@ -129,9 +133,10 @@ public class Order extends BaseEntity {
     }
 
     public void updateTrackingNumber(String trackingNumber) {
-        if (trackingNumber != null && trackingNumber.length() > OrderPolicy.TRACKING_NUMBER_MAX_LENGTH) {
+        if (trackingNumber != null && trackingNumber.trim().length() > OrderPolicy.TRACKING_NUMBER_MAX_LENGTH) {
             throw new IllegalArgumentException(OrderPolicy.TRACKING_NUMBER_TOO_LONG);
         }
         this.trackingNumber = trackingNumber;
+        this.trackingRegisteredAt = Instant.now();
     }
 }

--- a/src/main/java/com/ururulab/ururu/order/domain/repository/OrderItemRepository.java
+++ b/src/main/java/com/ururulab/ururu/order/domain/repository/OrderItemRepository.java
@@ -39,4 +39,18 @@ public interface OrderItemRepository extends JpaRepository<OrderItem, Long> {
             "WHERE oi.groupBuyOption.groupBuy.id = :groupBuyId " +
             "AND o.status = 'ORDERED'")
     Integer getTotalQuantityByGroupBuyId(@Param("groupBuyId") Long groupBuyId);
+
+    /**
+     * 주문 ID로 환불 가능한 아이템 조회
+     * 아직 환불되지 않은 주문 아이템들을 반환
+     */
+    @Query("SELECT oi FROM OrderItem oi " +
+            "WHERE oi.order.id = :orderId " +
+            "AND NOT EXISTS (" +
+            "  SELECT 1 FROM RefundItem ri " +
+            "  JOIN ri.refund r " +
+            "  WHERE ri.orderItem.id = oi.id " +
+            "  AND r.status IN ('APPROVED', 'COMPLETED', 'FAILED')" +
+            ")")
+    List<OrderItem> findRefundableItemsByOrderId(@Param("orderId") String orderId);
 }

--- a/src/main/java/com/ururulab/ururu/payment/controller/RefundController.java
+++ b/src/main/java/com/ururulab/ururu/payment/controller/RefundController.java
@@ -1,0 +1,80 @@
+package com.ururulab.ururu.payment.controller;
+
+import com.ururulab.ururu.global.domain.dto.ApiResponseFormat;
+import com.ururulab.ururu.payment.dto.request.RefundProcessRequestDto;
+import com.ururulab.ururu.payment.dto.request.RefundRequestDto;
+import com.ururulab.ururu.payment.dto.response.RefundCreateResponseDto;
+import com.ururulab.ururu.payment.dto.response.RefundProcessResponseDto;
+import com.ururulab.ururu.payment.service.RefundService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api")
+@Tag(name = "환불", description = "환불 요청 및 처리 API")
+public class RefundController {
+
+    private final RefundService refundService;
+
+    @Operation(summary = "환불 요청 생성", description = "주문에 대한 수동 환불을 요청합니다. Order 단위 전체 환불만 가능합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "201", description = "환불 요청 생성 성공"),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청 데이터 또는 환불 불가 상태"),
+            @ApiResponse(responseCode = "401", description = "인증 실패"),
+            @ApiResponse(responseCode = "403", description = "접근 권한 없음 (다른 회원의 주문)"),
+            @ApiResponse(responseCode = "404", description = "존재하지 않는 주문 또는 결제"),
+            @ApiResponse(responseCode = "409", description = "이미 진행 중인 환불 요청 또는 중복 환불")
+    })
+    @PostMapping("/orders/{orderId}/refund")
+    public ResponseEntity<ApiResponseFormat<RefundCreateResponseDto>> createRefundRequest(
+            @AuthenticationPrincipal Long memberId,
+            @PathVariable String orderId,
+            @Valid @RequestBody RefundRequestDto request
+    ) {
+        log.debug("환불 요청 생성 - 회원ID: {}, 주문ID: {}, 요청: {}", memberId, orderId, request);
+
+        RefundCreateResponseDto response = refundService.createRefundRequest(memberId, orderId, request);
+
+        return ResponseEntity
+                .status(HttpStatus.CREATED)
+                .body(ApiResponseFormat.success("환불 요청이 생성되었습니다", response));
+    }
+
+    @Operation(summary = "환불 요청 처리", description = "판매자가 환불 요청을 승인 또는 거절합니다. 승인 시 실제 PG 환불이 진행됩니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "환불 처리 완료"),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청 데이터 또는 처리 불가 상태"),
+            @ApiResponse(responseCode = "401", description = "인증 실패"),
+            @ApiResponse(responseCode = "403", description = "접근 권한 없음 (다른 판매자의 환불)"),
+            @ApiResponse(responseCode = "404", description = "존재하지 않는 환불"),
+            @ApiResponse(responseCode = "409", description = "이미 처리된 환불"),
+            @ApiResponse(responseCode = "500", description = "PG 환불 처리 실패")
+    })
+    @PatchMapping("/refunds/{refundId}")
+    public ResponseEntity<ApiResponseFormat<RefundProcessResponseDto>> processRefundRequest(
+            @AuthenticationPrincipal Long sellerId,
+            @PathVariable String refundId,
+            @Valid @RequestBody RefundProcessRequestDto request
+    ) {
+        log.debug("환불 요청 처리 - 판매자ID: {}, 환불ID: {}, 액션: {}", sellerId, refundId, request.action());
+
+        RefundProcessResponseDto response = refundService.processRefundRequest(sellerId, refundId, request);
+
+        String message = "APPROVE".equals(request.action()) ? "환불이 승인되었습니다" : "환불이 거절되었습니다";
+
+        return ResponseEntity.ok(
+                ApiResponseFormat.success(message, response)
+        );
+    }
+}

--- a/src/main/java/com/ururulab/ururu/payment/domain/entity/Refund.java
+++ b/src/main/java/com/ururulab/ururu/payment/domain/entity/Refund.java
@@ -55,7 +55,7 @@ public class Refund extends BaseEntity {
     @OneToMany(mappedBy = "refund", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<RefundItem> refundItems = new ArrayList<>();
 
-    public static Refund create(Payment payment, RefundType type, String reason, Integer amount, String returnTrackingNumber) {
+    public static Refund create(Payment payment, RefundType type, String reason, Integer amount, String returnTrackingNumber, RefundStatus status) {
         if (payment == null) {
             throw new IllegalArgumentException(RefundPolicy.PAYMENT_REQUIRED);
         }
@@ -77,11 +77,13 @@ public class Refund extends BaseEntity {
         if (amount > payment.getAmount()) {
             throw new IllegalArgumentException(RefundPolicy.AMOUNT_EXCEEDS_PAYMENT);
         }
-        if (type != RefundType.GROUPBUY_FAILED && (returnTrackingNumber == null || returnTrackingNumber.trim().isEmpty())) {
-            throw new IllegalArgumentException(RefundPolicy.RETURN_TRACKING_NUMBER_REQUIRED);
-        }
-        if (returnTrackingNumber != null && returnTrackingNumber.length() > RefundPolicy.RETURN_TRACKING_NUMBER_MAX_LENGTH) {
-            throw new IllegalArgumentException(RefundPolicy.RETURN_TRACKING_NUMBER_TOO_LONG);
+        if (status == RefundStatus.INITIATED && type != RefundType.GROUPBUY_FAILED) {
+            if (returnTrackingNumber == null || returnTrackingNumber.trim().isEmpty()) {
+                throw new IllegalArgumentException(RefundPolicy.RETURN_TRACKING_NUMBER_REQUIRED);
+            }
+            if (returnTrackingNumber != null && returnTrackingNumber.length() > RefundPolicy.RETURN_TRACKING_NUMBER_MAX_LENGTH) {
+                throw new IllegalArgumentException(RefundPolicy.RETURN_TRACKING_NUMBER_TOO_LONG);
+            }
         }
 
         Refund refund = new Refund();
@@ -90,7 +92,8 @@ public class Refund extends BaseEntity {
         refund.type = type;
         refund.reason = reason.trim();
         refund.amount = amount;
-        refund.status = RefundStatus.INITIATED;
+        refund.status = status;
+        refund.returnTrackingNumber = returnTrackingNumber;
 
         return refund;
     }

--- a/src/main/java/com/ururulab/ururu/payment/domain/entity/Refund.java
+++ b/src/main/java/com/ururulab/ururu/payment/domain/entity/Refund.java
@@ -43,6 +43,9 @@ public class Refund extends BaseEntity {
     @Column(nullable = false)
     private RefundStatus status;
 
+    @Column(length = RefundPolicy.RETURN_TRACKING_NUMBER_MAX_LENGTH)
+    private String returnTrackingNumber;
+
     @Column(length = RefundPolicy.REJECT_REASON_MAX_LENGTH)
     private String rejectReason;
 
@@ -52,7 +55,7 @@ public class Refund extends BaseEntity {
     @OneToMany(mappedBy = "refund", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<RefundItem> refundItems = new ArrayList<>();
 
-    public static Refund create(Payment payment, RefundType type, String reason, Integer amount) {
+    public static Refund create(Payment payment, RefundType type, String reason, Integer amount, String returnTrackingNumber) {
         if (payment == null) {
             throw new IllegalArgumentException(RefundPolicy.PAYMENT_REQUIRED);
         }
@@ -73,6 +76,12 @@ public class Refund extends BaseEntity {
         }
         if (amount > payment.getAmount()) {
             throw new IllegalArgumentException(RefundPolicy.AMOUNT_EXCEEDS_PAYMENT);
+        }
+        if (type != RefundType.GROUPBUY_FAILED && (returnTrackingNumber == null || returnTrackingNumber.trim().isEmpty())) {
+            throw new IllegalArgumentException(RefundPolicy.RETURN_TRACKING_NUMBER_REQUIRED);
+        }
+        if (returnTrackingNumber != null && returnTrackingNumber.length() > RefundPolicy.RETURN_TRACKING_NUMBER_MAX_LENGTH) {
+            throw new IllegalArgumentException(RefundPolicy.RETURN_TRACKING_NUMBER_TOO_LONG);
         }
 
         Refund refund = new Refund();

--- a/src/main/java/com/ururulab/ururu/payment/domain/policy/RefundPolicy.java
+++ b/src/main/java/com/ururulab/ururu/payment/domain/policy/RefundPolicy.java
@@ -8,6 +8,9 @@ public class RefundPolicy {
     // 정책 상수
     public static final int ID_LENGTH = 36;
     public static final int MIN_AMOUNT = 0;
+    public static final int MAX_AMOUNT = 100_000_000;
+    public static final int MIN_POINT = 0;
+    public static final int MAX_POINT = 100_000_000;
     public static final int REASON_MAX_LENGTH = 255;
     public static final int REJECT_REASON_MAX_LENGTH = 255;
     public static final int RETURN_TRACKING_NUMBER_MAX_LENGTH = 50;
@@ -19,7 +22,12 @@ public class RefundPolicy {
     public static final String REASON_REQUIRED = "환불 사유는 필수입니다.";
     public static final String AMOUNT_REQUIRED = "환불 금액은 필수입니다.";
     public static final String AMOUNT_MIN = "환불 금액은 0원 이상이어야 합니다.";
+    public static final String AMOUNT_MAX = "환불 금액은 최대 " + MAX_AMOUNT + "원까지 가능합니다.";
+    public static final String POINT_REQUIRED = "환불 포인트는 필수입니다.";
+    public static final String POINT_MIN = "환불 포인트는 0 이상이어야 합니다.";
+    public static final String POINT_MAX = "환불 포인트는 최대 " + MAX_POINT + "포인트까지 가능합니다.";
     public static final String AMOUNT_EXCEEDS_PAYMENT = "환불 금액이 결제 금액을 초과할 수 없습니다.";
+    public static final String POINT_EXCEEDS_PAYMENT = "환불 포인트가 결제 시 사용한 포인트를 초과할 수 없습니다.";
     public static final String REFUNDED_AT_REQUIRED = "환불 완료 시간은 필수입니다.";
     public static final String REJECT_REASON_REQUIRED = "거절 사유는 필수입니다.";
     public static final String INVALID_STATUS_FOR_APPROVAL = "승인 가능한 상태가 아닙니다.";

--- a/src/main/java/com/ururulab/ururu/payment/domain/policy/RefundPolicy.java
+++ b/src/main/java/com/ururulab/ururu/payment/domain/policy/RefundPolicy.java
@@ -10,6 +10,7 @@ public class RefundPolicy {
     public static final int MIN_AMOUNT = 0;
     public static final int REASON_MAX_LENGTH = 255;
     public static final int REJECT_REASON_MAX_LENGTH = 255;
+    public static final int RETURN_TRACKING_NUMBER_MAX_LENGTH = 50;
 
     // 에러 메시지
     public static final String PAYMENT_REQUIRED = "결제 정보는 필수입니다.";
@@ -26,4 +27,6 @@ public class RefundPolicy {
     public static final String INVALID_STATUS_FOR_COMPLETION = "완료 처리 가능한 상태가 아닙니다.";
     public static final String INVALID_STATUS_FOR_FAILURE = "실패 처리 가능한 상태가 아닙니다.";
     public static final String REFUND_ITEM_REQUIRED = "환불 아이템은 필수입니다.";
+    public static final String RETURN_TRACKING_NUMBER_REQUIRED = "물건 반송을 위한 운송장 번호는 필수입니다.";
+    public static final String RETURN_TRACKING_NUMBER_TOO_LONG = "운송장 번호는 " + RETURN_TRACKING_NUMBER_MAX_LENGTH + "자를 초과할 수 없습니다.";
 }

--- a/src/main/java/com/ururulab/ururu/payment/domain/repository/RefundRepository.java
+++ b/src/main/java/com/ururulab/ururu/payment/domain/repository/RefundRepository.java
@@ -8,6 +8,9 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.util.List;
+import java.util.Optional;
+
 public interface RefundRepository extends JpaRepository<Refund, String> {
 
     /**
@@ -28,5 +31,63 @@ public interface RefundRepository extends JpaRepository<Refund, String> {
             @Param("memberId") Long memberId,
             @Param("status") RefundStatus status,
             Pageable pageable
+    );
+
+    /**
+     * 환불 ID로 상세 정보 조회
+     * 환불 처리 시 연관 엔티티들 함께 조회
+     */
+    @Query("SELECT r FROM Refund r " +
+            "LEFT JOIN FETCH r.payment p " +
+            "LEFT JOIN FETCH p.order o " +
+            "LEFT JOIN FETCH p.member m " +
+            "LEFT JOIN FETCH r.refundItems ri " +
+            "LEFT JOIN FETCH ri.orderItem oi " +
+            "LEFT JOIN FETCH oi.groupBuyOption gbo " +
+            "LEFT JOIN FETCH gbo.groupBuy gb " +
+            "LEFT JOIN FETCH gb.product prod " +
+            "LEFT JOIN FETCH gbo.productOption po " +
+            "WHERE r.id = :refundId")
+    Optional<Refund> findByIdWithDetails(@Param("refundId") String refundId);
+
+    /**
+     * 주문에 대한 수동환불 진행중 여부 확인
+     * 수동환불은 Order 단위 전체 처리이므로 하나라도 진행중이면 중복 방지
+     *
+     * @param orderId 주문 ID
+     * @param memberId 회원 ID
+     * @return 진행중인 수동환불 정보
+     */
+    @Query("SELECT r FROM Refund r " +
+            "JOIN r.payment p " +
+            "WHERE p.order.id = :orderId " +
+            "AND p.member.id = :memberId " +
+            "AND r.status = 'INITIATED' " +
+            "AND r.type != 'GROUPBUY_FAILED'")
+    Optional<Refund> findActiveManualRefundByOrderAndMember(
+            @Param("orderId") String orderId,
+            @Param("memberId") Long memberId
+    );
+
+    /**
+     * 판매자의 환불 요청 목록 조회
+     * 판매자별 환불 관리용
+     *
+     * @param sellerId 판매자 ID
+     * @param status 환불 상태
+     * @return 환불 목록
+     */
+    @Query("SELECT r FROM Refund r " +
+            "JOIN r.payment p " +
+            "JOIN p.order o " +
+            "JOIN o.orderItems oi " +
+            "JOIN oi.groupBuyOption gbo " +
+            "JOIN gbo.groupBuy gb " +
+            "WHERE gb.seller.id = :sellerId " +
+            "AND r.status = :status " +
+            "ORDER BY r.createdAt DESC")
+    List<Refund> findBySellerId(
+            @Param("sellerId") Long sellerId,
+            @Param("status") RefundStatus status
     );
 }

--- a/src/main/java/com/ururulab/ururu/payment/domain/repository/RefundRepository.java
+++ b/src/main/java/com/ururulab/ururu/payment/domain/repository/RefundRepository.java
@@ -90,4 +90,13 @@ public interface RefundRepository extends JpaRepository<Refund, String> {
             @Param("sellerId") Long sellerId,
             @Param("status") RefundStatus status
     );
+
+    /**
+     * 주문 ID로 환불 목록 조회
+     * 동일 주문에 대한 기존 환불 내역 확인용
+     */
+    @Query("SELECT r FROM Refund r " +
+            "JOIN r.payment p " +
+            "WHERE p.order.id = :orderId")
+    List<Refund> findByOrderId(@Param("orderId") String orderId);
 }

--- a/src/main/java/com/ururulab/ururu/payment/dto/request/RefundProcessRequestDto.java
+++ b/src/main/java/com/ururulab/ururu/payment/dto/request/RefundProcessRequestDto.java
@@ -1,0 +1,17 @@
+package com.ururulab.ururu.payment.dto.request;
+
+import com.ururulab.ururu.payment.dto.validation.RefundValidationConstants;
+import com.ururulab.ururu.payment.dto.validation.RefundValidationMessages;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+
+public record RefundProcessRequestDto(
+        @NotBlank(message = RefundValidationMessages.ACTION_REQUIRED)
+        @Pattern(regexp = RefundValidationConstants.REFUND_ACTION_PATTERN, message = RefundValidationMessages.ACTION_INVALID)
+        String action,
+
+        @Size(max = RefundValidationConstants.REJECT_REASON_MAX_LENGTH, message = RefundValidationMessages.REJECT_REASON_MAX_LENGTH)
+        String rejectReason
+) {
+}

--- a/src/main/java/com/ururulab/ururu/payment/dto/request/RefundRequestDto.java
+++ b/src/main/java/com/ururulab/ururu/payment/dto/request/RefundRequestDto.java
@@ -14,6 +14,9 @@ public record RefundRequestDto(
 
         @NotBlank(message = RefundValidationMessages.REASON_REQUIRED)
         @Size(max = RefundValidationConstants.REASON_MAX_LENGTH, message = RefundValidationMessages.REASON_MAX_LENGTH)
-        String reason
+        String reason,
+
+        @Size(max = RefundValidationConstants.RETURN_TRACKING_NUMBER_MAX_LENGTH, message = RefundValidationMessages.RETURN_TRACKING_NUMBER_TOO_LONG)
+        String returnTrackingNumber  //
 ) {
 }

--- a/src/main/java/com/ururulab/ururu/payment/dto/request/RefundRequestDto.java
+++ b/src/main/java/com/ururulab/ururu/payment/dto/request/RefundRequestDto.java
@@ -1,0 +1,19 @@
+package com.ururulab.ururu.payment.dto.request;
+
+import com.ururulab.ururu.global.validation.EnumValue;
+import com.ururulab.ururu.payment.domain.entity.enumerated.RefundType;
+import com.ururulab.ururu.payment.dto.validation.RefundValidationConstants;
+import com.ururulab.ururu.payment.dto.validation.RefundValidationMessages;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record RefundRequestDto(
+        @NotBlank(message = RefundValidationMessages.TYPE_REQUIRED)
+        @EnumValue(enumClass = RefundType.class, message = RefundValidationMessages.TYPE_INVALID)
+        String type,
+
+        @NotBlank(message = RefundValidationMessages.REASON_REQUIRED)
+        @Size(max = RefundValidationConstants.REASON_MAX_LENGTH, message = RefundValidationMessages.REASON_MAX_LENGTH)
+        String reason
+) {
+}

--- a/src/main/java/com/ururulab/ururu/payment/dto/response/RefundCreateResponseDto.java
+++ b/src/main/java/com/ururulab/ururu/payment/dto/response/RefundCreateResponseDto.java
@@ -1,0 +1,16 @@
+package com.ururulab.ururu.payment.dto.response;
+
+import com.ururulab.ururu.payment.domain.entity.enumerated.RefundStatus;
+import com.ururulab.ururu.payment.domain.entity.enumerated.RefundType;
+
+/**
+ * 환불 생성 응답 DTO
+ * POST /api/orders/{orderId}/refund 응답
+ */
+public record RefundCreateResponseDto(
+        String refundId,
+        RefundStatus status,
+        RefundType type,
+        Integer amount
+) {
+}

--- a/src/main/java/com/ururulab/ururu/payment/dto/response/RefundProcessResponseDto.java
+++ b/src/main/java/com/ururulab/ururu/payment/dto/response/RefundProcessResponseDto.java
@@ -1,0 +1,17 @@
+package com.ururulab.ururu.payment.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.ururulab.ururu.payment.domain.entity.enumerated.RefundStatus;
+
+/**
+ * 환불 처리 응답 DTO
+ * PATCH /api/refunds/{refundId} 응답
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record RefundProcessResponseDto(
+        String refundId,
+        String orderId,
+        RefundStatus status,
+        String rejectReason  // REJECT 일때
+) {
+}

--- a/src/main/java/com/ururulab/ururu/payment/dto/validation/RefundValidationConstants.java
+++ b/src/main/java/com/ururulab/ururu/payment/dto/validation/RefundValidationConstants.java
@@ -1,0 +1,11 @@
+package com.ururulab.ururu.payment.dto.validation;
+
+import lombok.experimental.UtilityClass;
+
+@UtilityClass
+public class RefundValidationConstants {
+    public static final int REASON_MAX_LENGTH = 255;
+    public static final int REJECT_REASON_MAX_LENGTH = 255;
+
+    public static final String REFUND_ACTION_PATTERN = "^(APPROVE|REJECT)$";
+}

--- a/src/main/java/com/ururulab/ururu/payment/dto/validation/RefundValidationConstants.java
+++ b/src/main/java/com/ururulab/ururu/payment/dto/validation/RefundValidationConstants.java
@@ -6,6 +6,8 @@ import lombok.experimental.UtilityClass;
 public class RefundValidationConstants {
     public static final int REASON_MAX_LENGTH = 255;
     public static final int REJECT_REASON_MAX_LENGTH = 255;
+    public static final int RETURN_TRACKING_NUMBER_MAX_LENGTH = 50;
+
 
     public static final String REFUND_ACTION_PATTERN = "^(APPROVE|REJECT)$";
 }

--- a/src/main/java/com/ururulab/ururu/payment/dto/validation/RefundValidationMessages.java
+++ b/src/main/java/com/ururulab/ururu/payment/dto/validation/RefundValidationMessages.java
@@ -2,6 +2,8 @@ package com.ururulab.ururu.payment.dto.validation;
 
 import lombok.experimental.UtilityClass;
 
+import static com.ururulab.ururu.payment.dto.validation.RefundValidationConstants.RETURN_TRACKING_NUMBER_MAX_LENGTH;
+
 @UtilityClass
 public class RefundValidationMessages {
 
@@ -15,4 +17,5 @@ public class RefundValidationMessages {
     public static final String ACTION_REQUIRED = "처리 액션은 필수입니다.";
     public static final String ACTION_INVALID = "유효하지 않은 액션입니다.";
     public static final String REJECT_REASON_MAX_LENGTH = "거절 사유는 255자를 초과할 수 없습니다.";
+    public static final String RETURN_TRACKING_NUMBER_TOO_LONG = "운송장 번호는 " + RETURN_TRACKING_NUMBER_MAX_LENGTH + "자를 초과할 수 없습니다.";
 }

--- a/src/main/java/com/ururulab/ururu/payment/dto/validation/RefundValidationMessages.java
+++ b/src/main/java/com/ururulab/ururu/payment/dto/validation/RefundValidationMessages.java
@@ -1,0 +1,18 @@
+package com.ururulab.ururu.payment.dto.validation;
+
+import lombok.experimental.UtilityClass;
+
+@UtilityClass
+public class RefundValidationMessages {
+
+    // 환불 요청 관련
+    public static final String TYPE_REQUIRED = "환불 타입은 필수입니다.";
+    public static final String TYPE_INVALID = "유효하지 않은 환불 타입입니다.";
+    public static final String REASON_REQUIRED = "환불 사유는 필수입니다.";
+    public static final String REASON_MAX_LENGTH = "환불 사유는 255자를 초과할 수 없습니다.";
+
+    // 환불 처리 관련
+    public static final String ACTION_REQUIRED = "처리 액션은 필수입니다.";
+    public static final String ACTION_INVALID = "유효하지 않은 액션입니다.";
+    public static final String REJECT_REASON_MAX_LENGTH = "거절 사유는 255자를 초과할 수 없습니다.";
+}

--- a/src/main/java/com/ururulab/ururu/payment/service/RefundService.java
+++ b/src/main/java/com/ururulab/ururu/payment/service/RefundService.java
@@ -1,0 +1,431 @@
+package com.ururulab.ururu.payment.service;
+
+import com.ururulab.ururu.global.exception.BusinessException;
+import com.ururulab.ururu.global.exception.error.ErrorCode;
+import com.ururulab.ururu.groupBuy.domain.repository.GroupBuyOptionRepository;
+import com.ururulab.ururu.member.domain.entity.Member;
+import com.ururulab.ururu.member.domain.repository.MemberRepository;
+import com.ururulab.ururu.order.domain.entity.Order;
+import com.ururulab.ururu.order.domain.entity.OrderItem;
+import com.ururulab.ururu.order.domain.entity.enumerated.OrderStatus;
+import com.ururulab.ururu.order.domain.repository.OrderItemRepository;
+import com.ururulab.ururu.order.domain.repository.OrderRepository;
+import com.ururulab.ururu.payment.domain.entity.Payment;
+import com.ururulab.ururu.payment.domain.entity.PointTransaction;
+import com.ururulab.ururu.payment.domain.entity.Refund;
+import com.ururulab.ururu.payment.domain.entity.RefundItem;
+import com.ururulab.ururu.payment.domain.entity.enumerated.PointSource;
+import com.ururulab.ururu.payment.domain.entity.enumerated.RefundStatus;
+import com.ururulab.ururu.payment.domain.entity.enumerated.RefundType;
+import com.ururulab.ururu.payment.domain.repository.PaymentRepository;
+import com.ururulab.ururu.payment.domain.repository.PointTransactionRepository;
+import com.ururulab.ururu.payment.domain.repository.RefundRepository;
+import com.ururulab.ururu.payment.dto.request.RefundProcessRequestDto;
+import com.ururulab.ururu.payment.dto.request.RefundRequestDto;
+import com.ururulab.ururu.payment.dto.response.RefundCreateResponseDto;
+import com.ururulab.ururu.payment.dto.response.RefundProcessResponseDto;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+import java.util.Optional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class RefundService {
+
+    private final RefundRepository refundRepository;
+    private final OrderRepository orderRepository;
+    private final OrderItemRepository orderItemRepository;
+    private final PaymentRepository paymentRepository;
+    private final MemberRepository memberRepository;
+    private final GroupBuyOptionRepository groupBuyOptionRepository;
+    private final PointTransactionRepository pointTransactionRepository;
+    private final PaymentService paymentService;
+
+    /**
+     * 수동 환불 요청을 생성합니다.
+     * Order 단위 전체 환불만 지원하며, 환불 타입에 따라 운송장 등록 전후 기간 제한을 적용합니다.
+     * 운송장 등록 전인 경우 자동 승인되어 즉시 환불 처리됩니다.
+     *
+     * @param memberId 환불을 요청하는 회원 ID
+     * @param orderId 환불 대상 주문 ID
+     * @param request 환불 요청 정보 (타입, 사유, 반송 운송장)
+     * @return 생성된 환불 정보
+     * @throws BusinessException 주문이 존재하지 않거나, 환불 불가 상태이거나, 중복 요청인 경우
+     */
+    @Transactional
+    public RefundCreateResponseDto createRefundRequest(Long memberId, String orderId, RefundRequestDto request) {
+        log.debug("수동 환불 요청 생성 - 회원ID: {}, 주문ID: {}, 타입: {}", memberId, orderId, request.type());
+
+        Order order = findOrderById(orderId);
+        validateOrderOwnership(order, memberId);
+        validateOrderForRefund(order);
+        validateNoDuplicateRefund(orderId, memberId);
+
+        List<OrderItem> refundableItems = orderItemRepository.findRefundableItemsByOrderId(orderId);
+        if (refundableItems.isEmpty()) {
+            throw new BusinessException(ErrorCode.CART_ITEMS_EMPTY);
+        }
+
+        RefundType refundType = RefundType.from(request.type());
+        boolean autoApprove = validateRefundPeriod(order, refundType);
+
+        Payment payment = findPaymentByOrderId(orderId);
+        Integer itemAmount = calculateItemAmount(refundableItems);
+        Integer pointAmount = calculateRemainingPoint(payment, orderId);
+
+        RefundStatus refundStatus = autoApprove ? RefundStatus.APPROVED : RefundStatus.INITIATED;
+
+        Refund refund = Refund.create(payment, refundType, request.reason(),
+                itemAmount, pointAmount, request.returnTrackingNumber(), refundStatus);
+
+        refundableItems.forEach(orderItem -> {
+            RefundItem refundItem = RefundItem.create(orderItem);
+            refund.addRefundItem(refundItem);
+        });
+
+        Refund savedRefund = refundRepository.save(refund);
+
+        if (autoApprove) {
+            processRefundApproval(savedRefund);
+            log.debug("자동 승인으로 환불 처리 완료 - 환불ID: {}", savedRefund.getId());
+        } else {
+            log.debug("수동 환불 요청 생성 완료 - 환불ID: {}, 판매자 승인 대기", savedRefund.getId());
+        }
+
+        return new RefundCreateResponseDto(
+                savedRefund.getId(),
+                savedRefund.getStatus(),
+                savedRefund.getType(),
+                itemAmount + pointAmount
+        );
+    }
+
+    /**
+     * 판매자의 환불 요청 처리를 수행합니다.
+     * 승인 시 포인트 복구, 재고 복구, 주문 상태 변경, PG 환불 요청을 순차적으로 진행합니다.
+     * 거절 시 환불 상태를 REJECTED로 변경하고 거절 사유를 기록합니다.
+     *
+     * @param sellerId 환불을 처리하는 판매자 ID
+     * @param refundId 처리할 환불 ID
+     * @param request 처리 요청 정보 (승인/거절, 거절 사유)
+     * @return 처리 결과 정보
+     * @throws BusinessException 환불이 존재하지 않거나, 이미 처리되었거나, 권한이 없는 경우
+     */
+    @Transactional
+    public RefundProcessResponseDto processRefundRequest(Long sellerId, String refundId, RefundProcessRequestDto request) {
+        log.debug("환불 요청 처리 - 판매자ID: {}, 환불ID: {}, 액션: {}", sellerId, refundId, request.action());
+
+        Refund refund = findRefundById(refundId);
+        validateRefundForProcessing(refund);
+        validateSellerAuthority(refund, sellerId);
+
+        if ("APPROVE".equals(request.action())) {
+            refund.markAsApproved();
+            return processRefundApproval(refund);
+        } else if ("REJECT".equals(request.action())) {
+            refund.markAsRejected(request.rejectReason());
+            return processRefundRejection(refund, request.rejectReason());
+        } else {
+            throw new BusinessException(ErrorCode.INVALID_ARGUMENT, "액션은 APPROVE 또는 REJECT만 가능합니다.");
+        }
+    }
+
+    /**
+     * 환불 승인 처리 로직을 수행합니다.
+     * 포인트 복구, 재고 복구, 주문/결제 상태 업데이트, PG 환불 요청을 순차적으로 처리합니다.
+     *
+     * @param refund 승인 처리할 환불 엔티티
+     * @return 승인 처리 결과
+     */
+    private RefundProcessResponseDto processRefundApproval(Refund refund) {
+        log.debug("환불 승인 처리 시작 - 환불ID: {}", refund.getId());
+
+        restorePointsToCustomer(refund);
+        restoreStockToInventory(refund);
+        updateOrderAndPaymentStatus(refund);
+        requestPgRefund(refund);
+
+        log.debug("환불 승인 처리 완료 - 환불ID: {}", refund.getId());
+
+        return new RefundProcessResponseDto(
+                refund.getId(),
+                refund.getPayment().getOrder().getId(),
+                refund.getStatus(),
+                null
+        );
+    }
+
+    /**
+     * 환불 거절 처리 로직을 수행합니다.
+     * 환불 상태를 REJECTED로 변경하고 거절 사유를 기록합니다.
+     *
+     * @param refund 거절 처리할 환불 엔티티
+     * @param rejectReason 거절 사유
+     * @return 거절 처리 결과
+     */
+    private RefundProcessResponseDto processRefundRejection(Refund refund, String rejectReason) {
+        log.debug("환불 거절 처리 - 환불ID: {}, 사유: {}", refund.getId(), rejectReason);
+
+        return new RefundProcessResponseDto(
+                refund.getId(),
+                refund.getPayment().getOrder().getId(),
+                refund.getStatus(),
+                rejectReason
+        );
+    }
+
+    /**
+     * 고객에게 환불 포인트를 복구합니다.
+     * 회원의 포인트를 증가시키고 포인트 거래 내역을 기록합니다.
+     *
+     * @param refund 포인트 복구 대상 환불 엔티티
+     * @throws BusinessException 회원이 존재하지 않는 경우
+     */
+    private void restorePointsToCustomer(Refund refund) {
+        Integer pointsToRestore = refund.getPoint();
+
+        if (pointsToRestore > 0) {
+            Member member = refund.getPayment().getMember();
+
+            int updatedRows = memberRepository.increasePoints(member.getId(), pointsToRestore);
+            if (updatedRows == 0) {
+                throw new BusinessException(ErrorCode.MEMBER_NOT_FOUND);
+            }
+
+            PointTransaction pointTransaction = PointTransaction.createEarned(
+                    member, PointSource.REFUND, pointsToRestore, "환불로 인한 포인트 복구"
+            );
+            pointTransactionRepository.save(pointTransaction);
+
+            log.debug("포인트 복구 완료 - 회원ID: {}, 복구 포인트: {}P", member.getId(), pointsToRestore);
+        }
+    }
+
+    /**
+     * 환불된 상품의 재고를 복구합니다.
+     * 각 환불 아이템의 수량만큼 해당 공동구매 옵션의 재고를 증가시킵니다.
+     *
+     * @param refund 재고 복구 대상 환불 엔티티
+     */
+    private void restoreStockToInventory(Refund refund) {
+        refund.getRefundItems().forEach(refundItem -> {
+            Long optionId = refundItem.getOrderItem().getGroupBuyOption().getId();
+            Integer quantity = refundItem.getOrderItem().getQuantity();
+
+            int updatedRows = groupBuyOptionRepository.increaseStock(optionId, quantity);
+            if (updatedRows == 0) {
+                log.warn("재고 복구 실패 - 옵션ID: {}, 수량: {}", optionId, quantity);
+            } else {
+                log.debug("재고 복구 완료 - 옵션ID: {}, 복구 수량: {}개", optionId, quantity);
+            }
+        });
+    }
+
+    /**
+     * 수동 환불에 따른 주문 및 결제 상태를 업데이트합니다.
+     * 수동 환불은 항상 Order 단위 전체 환불이므로 상태를 REFUNDED로 변경합니다.
+     *
+     * @param refund 상태 업데이트 대상 환불 엔티티
+     */
+    private void updateOrderAndPaymentStatus(Refund refund) {
+        Payment payment = refund.getPayment();
+        Order order = payment.getOrder();
+
+        order.changeStatus(OrderStatus.REFUNDED, "수동 환불 완료");
+        payment.markAsRefunded(Instant.now());
+
+        log.debug("주문/결제 상태 업데이트 완료 - 주문ID: {}", order.getId());
+    }
+
+    /**
+     * PG 환불 요청을 처리합니다.
+     * PaymentService를 통해 토스페이먼츠 환불 API를 호출합니다.
+     * 환불 실패 시 상태를 FAILED로 변경하고 별도 재시도 로직에서 처리됩니다.
+     *
+     * @param refund PG 환불 요청 대상 환불 엔티티
+     */
+    private void requestPgRefund(Refund refund) {
+        try {
+            // TODO: PaymentService의 PG 환불 메서드 호출 구현 예정
+            // paymentService.requestRefundToToss(refund);
+            log.debug("PG 환불 요청 완료 - 환불ID: {}", refund.getId());
+        } catch (Exception e) {
+            log.error("PG 환불 요청 실패 - 환불ID: {}", refund.getId(), e);
+            refund.markAsFailed();
+        }
+    }
+
+    /**
+     * 환불 기간을 검증하고 자동 승인 여부를 결정합니다.
+     * 운송장 등록 전이면 자동 승인, 등록 후라면 환불 타입에 따라 기간 제한을 적용합니다.
+     *
+     * @param order 환불 대상 주문
+     * @param refundType 환불 타입
+     * @return 자동 승인 여부 (true: 자동 승인, false: 판매자 승인 필요)
+     * @throws BusinessException 환불 기간이 만료된 경우
+     */
+    private boolean validateRefundPeriod(Order order, RefundType refundType) {
+        if (order.getTrackingRegisteredAt() == null) {
+            return true;
+        }
+
+        int allowedDays = (refundType == RefundType.CHANGE_OF_MIND) ? 7 : 30;
+        Instant deadline = order.getTrackingRegisteredAt().plus(allowedDays, ChronoUnit.DAYS);
+
+        if (Instant.now().isAfter(deadline)) {
+            throw new BusinessException(ErrorCode.REFUND_PERIOD_EXPIRED, allowedDays);
+        }
+
+        return false;
+    }
+
+    /**
+     * 환불 대상 상품들의 금액을 계산합니다.
+     *
+     * @param refundableItems 환불 대상 주문 아이템 목록
+     * @return 총 상품 금액
+     */
+    private Integer calculateItemAmount(List<OrderItem> refundableItems) {
+        return refundableItems.stream()
+                .mapToInt(item -> item.getGroupBuyOption().getSalePrice() * item.getQuantity())
+                .sum();
+    }
+
+    /**
+     * 환불 가능한 남은 포인트를 계산합니다.
+     * 전체 사용 포인트에서 이미 다른 환불로 복구된 포인트를 제외합니다.
+     *
+     * @param payment 결제 정보
+     * @param orderId 주문 ID
+     * @return 환불 가능한 남은 포인트
+     */
+    private Integer calculateRemainingPoint(Payment payment, String orderId) {
+        Integer totalUsedPoint = payment.getPoint();
+
+        Integer alreadyRefundedPoint = refundRepository.findByOrderId(orderId)
+                .stream()
+                .filter(refund -> refund.getStatus() == RefundStatus.APPROVED ||
+                        refund.getStatus() == RefundStatus.COMPLETED)
+                .mapToInt(Refund::getPoint)
+                .sum();
+
+        return totalUsedPoint - alreadyRefundedPoint;
+    }
+
+    /**
+     * 주문 ID로 주문을 조회합니다.
+     *
+     * @param orderId 주문 ID
+     * @return 주문 엔티티
+     * @throws BusinessException 주문이 존재하지 않는 경우
+     */
+    private Order findOrderById(String orderId) {
+        return orderRepository.findById(orderId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.ORDER_NOT_FOUND));
+    }
+
+    /**
+     * 환불 ID로 환불을 조회합니다.
+     *
+     * @param refundId 환불 ID
+     * @return 환불 엔티티
+     * @throws BusinessException 환불이 존재하지 않는 경우
+     */
+    private Refund findRefundById(String refundId) {
+        return refundRepository.findByIdWithDetails(refundId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.REFUND_NOT_FOUND));
+    }
+
+    /**
+     * 주문 ID로 결제 정보를 조회합니다.
+     *
+     * @param orderId 주문 ID
+     * @return 결제 엔티티
+     * @throws BusinessException 결제 정보가 존재하지 않는 경우
+     */
+    private Payment findPaymentByOrderId(String orderId) {
+        return paymentRepository.findByOrderId(orderId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.PAYMENT_NOT_FOUND));
+    }
+
+    /**
+     * 주문 소유권을 검증합니다.
+     *
+     * @param order 검증할 주문
+     * @param memberId 요청 회원 ID
+     * @throws BusinessException 주문 소유자가 아닌 경우
+     */
+    private void validateOrderOwnership(Order order, Long memberId) {
+        if (!order.getMember().getId().equals(memberId)) {
+            throw new BusinessException(ErrorCode.ACCESS_DENIED);
+        }
+    }
+
+    /**
+     * 주문이 환불 가능한 상태인지 검증합니다.
+     *
+     * @param order 검증할 주문
+     * @throws BusinessException 환불 불가능한 주문 상태인 경우
+     */
+    private void validateOrderForRefund(Order order) {
+        if (order.getStatus() != OrderStatus.ORDERED && order.getStatus() != OrderStatus.PARTIAL_REFUNDED) {
+            throw new BusinessException(ErrorCode.ORDER_NOT_PENDING);
+        }
+    }
+
+    /**
+     * 중복 환불 요청이 없는지 검증합니다.
+     *
+     * @param orderId 주문 ID
+     * @param memberId 요청 회원 ID
+     * @throws BusinessException 이미 진행 중인 환불 요청이 있는 경우
+     */
+    private void validateNoDuplicateRefund(String orderId, Long memberId) {
+        Optional<Refund> existingRefund = refundRepository.findActiveManualRefundByOrderAndMember(orderId, memberId);
+        if (existingRefund.isPresent()) {
+            throw new BusinessException(ErrorCode.DUPLICATE_REFUND_REQUEST);
+        }
+    }
+
+    /**
+     * 환불이 처리 가능한 상태인지 검증합니다.
+     *
+     * @param refund 검증할 환불
+     * @throws BusinessException 처리 불가능한 환불 상태인 경우
+     */
+    private void validateRefundForProcessing(Refund refund) {
+        if (!refund.isInitiated()) {
+            throw new BusinessException(ErrorCode.REFUND_ALREADY_PROCESSED);
+        }
+    }
+
+    /**
+     * 판매자가 해당 환불을 처리할 권한이 있는지 검증합니다.
+     *
+     * @param refund 검증할 환불
+     * @param sellerId 요청 판매자 ID
+     * @throws BusinessException 처리 권한이 없는 경우
+     */
+    private void validateSellerAuthority(Refund refund, Long sellerId) {
+        boolean hasAuthority = refund.getRefundItems().stream()
+                .anyMatch(refundItem -> {
+                    Long refundSellerId = refundItem.getOrderItem()
+                            .getGroupBuyOption()
+                            .getGroupBuy()
+                            .getSeller()
+                            .getId();
+                    return refundSellerId.equals(sellerId);
+                });
+
+        if (!hasAuthority) {
+            throw new BusinessException(ErrorCode.ACCESS_DENIED);
+        }
+    }
+}

--- a/src/test/java/com/ururulab/ururu/payment/service/RefundServiceTest.java
+++ b/src/test/java/com/ururulab/ururu/payment/service/RefundServiceTest.java
@@ -1,0 +1,304 @@
+package com.ururulab.ururu.payment.service;
+
+import com.ururulab.ururu.global.exception.BusinessException;
+import com.ururulab.ururu.global.exception.error.ErrorCode;
+import com.ururulab.ururu.groupBuy.domain.repository.GroupBuyOptionRepository;
+import com.ururulab.ururu.member.domain.repository.MemberRepository;
+import com.ururulab.ururu.order.domain.repository.OrderItemRepository;
+import com.ururulab.ururu.order.domain.repository.OrderRepository;
+import com.ururulab.ururu.payment.domain.entity.Refund;
+import com.ururulab.ururu.payment.domain.entity.enumerated.RefundStatus;
+import com.ururulab.ururu.payment.domain.entity.enumerated.RefundType;
+import com.ururulab.ururu.payment.domain.repository.PaymentRepository;
+import com.ururulab.ururu.payment.domain.repository.PointTransactionRepository;
+import com.ururulab.ururu.payment.domain.repository.RefundRepository;
+import com.ururulab.ururu.payment.dto.request.RefundProcessRequestDto;
+import com.ururulab.ururu.payment.dto.request.RefundRequestDto;
+import com.ururulab.ururu.payment.dto.response.RefundCreateResponseDto;
+import com.ururulab.ururu.payment.dto.response.RefundProcessResponseDto;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("RefundService 테스트")
+class RefundServiceTest {
+
+    @InjectMocks
+    private RefundService refundService;
+
+    @Mock
+    private RefundRepository refundRepository;
+
+    @Mock
+    private PaymentRepository paymentRepository;
+
+    @Mock
+    private PointTransactionRepository pointTransactionRepository;
+
+    @Mock
+    private OrderRepository orderRepository;
+
+    @Mock
+    private MemberRepository memberRepository;
+
+    @Mock
+    private GroupBuyOptionRepository groupBuyOptionRepository;
+
+    @Mock
+    private OrderItemRepository orderItemRepository;
+
+    private RefundTestFixture.RefundTestScenario scenario;
+
+    @BeforeEach
+    void setUp() {
+        scenario = RefundTestFixture.createCompleteScenario();
+    }
+
+    @Nested
+    @DisplayName("환불 요청 생성")
+    class CreateRefundRequestTest {
+
+        @Test
+        @DisplayName("성공 - 운송장 등록 전 자동 승인")
+        void createRefundRequest_beforeTrackingRegistered_autoApprove() {
+            // given
+            RefundRequestDto request = RefundTestFixture.createChangeOfMindRequest();
+
+            setupBasicMocks();
+            given(refundRepository.findActiveManualRefundByOrderAndMember(scenario.order.getId(), scenario.member.getId()))
+                    .willReturn(Optional.empty());
+            given(orderItemRepository.findRefundableItemsByOrderId(scenario.order.getId()))
+                    .willReturn(List.of(scenario.orderItem));
+            given(refundRepository.save(any(Refund.class)))
+                    .willAnswer(invocation -> invocation.getArgument(0));
+
+            // 자동 승인 시 필요한 Mock들 추가
+            given(memberRepository.increasePoints(eq(scenario.member.getId()), anyInt())).willReturn(1);
+            given(groupBuyOptionRepository.increaseStock(eq(scenario.groupBuyOption.getId()), anyInt())).willReturn(1);
+
+            // 디버깅용 로그
+            System.out.println("Test Order ID: " + scenario.order.getId());
+            System.out.println("Test Payment ID: " + scenario.payment.getId());
+
+            // when
+            RefundCreateResponseDto result = refundService.createRefundRequest(
+                    scenario.member.getId(), scenario.order.getId(), request);
+
+            // then
+            assertThat(result.status()).isEqualTo(RefundStatus.APPROVED); // 자동 승인
+            assertThat(result.type()).isEqualTo(RefundType.CHANGE_OF_MIND);
+            assertThat(result.amount()).isPositive(); // 일단 양수인지만 확인
+
+            verify(memberRepository).increasePoints(eq(scenario.member.getId()), anyInt());
+            verify(pointTransactionRepository).save(any());
+            verify(groupBuyOptionRepository).increaseStock(eq(scenario.groupBuyOption.getId()), anyInt());
+        }
+
+        @Test
+        @DisplayName("실패 - 존재하지 않는 주문")
+        void createRefundRequest_orderNotFound_fail() {
+            // given
+            RefundRequestDto request = RefundTestFixture.createChangeOfMindRequest();
+
+            given(orderRepository.findById("non-existent-order")).willReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> refundService.createRefundRequest(
+                    scenario.member.getId(), "non-existent-order", request))
+                    .isInstanceOf(BusinessException.class)
+                    .extracting(ex -> ((BusinessException) ex).getErrorCode())
+                    .isEqualTo(ErrorCode.ORDER_NOT_FOUND);
+        }
+
+        @Test
+        @DisplayName("실패 - 환불 가능한 아이템 없음")
+        void createRefundRequest_noRefundableItems_fail() {
+            // given
+            RefundRequestDto request = RefundTestFixture.createChangeOfMindRequest();
+
+            // 이 테스트에 필요한 최소 Mock만 설정
+            given(orderRepository.findById(eq("test-order-id")))
+                    .willReturn(Optional.of(scenario.order));
+            given(refundRepository.findActiveManualRefundByOrderAndMember(scenario.order.getId(), scenario.member.getId()))
+                    .willReturn(Optional.empty());
+            given(orderItemRepository.findRefundableItemsByOrderId(scenario.order.getId()))
+                    .willReturn(List.of()); // 환불 가능한 아이템 없음
+
+            // when & then
+            assertThatThrownBy(() -> refundService.createRefundRequest(
+                    scenario.member.getId(), scenario.order.getId(), request))
+                    .isInstanceOf(BusinessException.class)
+                    .extracting(ex -> ((BusinessException) ex).getErrorCode())
+                    .isEqualTo(ErrorCode.CART_ITEMS_EMPTY);
+        }
+
+        @Test
+        @DisplayName("실패 - 이미 진행 중인 환불 요청")
+        void createRefundRequest_duplicateRequest_fail() {
+            // given
+            RefundRequestDto request = RefundTestFixture.createChangeOfMindRequest();
+            Refund existingRefund = RefundTestFixture.createRefund("existing-refund",
+                    scenario.payment, RefundType.CHANGE_OF_MIND, "기존 요청",
+                    10000, 500, RefundStatus.INITIATED);
+
+            // 이 테스트에 필요한 최소 Mock만 설정
+            given(orderRepository.findById(eq("test-order-id")))
+                    .willReturn(Optional.of(scenario.order));
+            given(refundRepository.findActiveManualRefundByOrderAndMember(
+                    scenario.order.getId(), scenario.member.getId()))
+                    .willReturn(Optional.of(existingRefund));
+
+            // when & then
+            assertThatThrownBy(() -> refundService.createRefundRequest(
+                    scenario.member.getId(), scenario.order.getId(), request))
+                    .isInstanceOf(BusinessException.class)
+                    .extracting(ex -> ((BusinessException) ex).getErrorCode())
+                    .isEqualTo(ErrorCode.DUPLICATE_REFUND_REQUEST);
+        }
+    }
+
+    @Nested
+    @DisplayName("환불 요청 처리")
+    class ProcessRefundRequestTest {
+
+        @Test
+        @DisplayName("성공 - 판매자 승인")
+        void processRefundRequest_approve_success() {
+            // given
+            String refundId = "refund-123";
+            Long sellerId = scenario.seller.getId();
+            RefundProcessRequestDto request = RefundTestFixture.createApproveRequest();
+
+            // RefundItem을 제대로 설정한 Refund 생성
+            Refund refund = RefundTestFixture.createRefundWithItems(refundId, scenario.payment,
+                    RefundType.CHANGE_OF_MIND, "단순 변심", 15000, 1000, RefundStatus.INITIATED, scenario.orderItem);
+
+            given(refundRepository.findByIdWithDetails(refundId)).willReturn(Optional.of(refund));
+            given(memberRepository.increasePoints(eq(scenario.member.getId()), eq(1000))).willReturn(1);
+            given(groupBuyOptionRepository.increaseStock(eq(scenario.groupBuyOption.getId()), eq(2))).willReturn(1);
+
+            // when
+            RefundProcessResponseDto result = refundService.processRefundRequest(sellerId, refundId, request);
+
+            // then
+            assertThat(result.refundId()).isEqualTo(refundId);
+            assertThat(result.status()).isEqualTo(RefundStatus.APPROVED);
+            assertThat(result.rejectReason()).isNull();
+
+            verify(memberRepository).increasePoints(eq(scenario.member.getId()), eq(1000));
+            verify(pointTransactionRepository).save(any());
+            verify(groupBuyOptionRepository).increaseStock(eq(scenario.groupBuyOption.getId()), eq(2));
+        }
+
+        @Test
+        @DisplayName("성공 - 판매자 거절")
+        void processRefundRequest_reject_success() {
+            // given
+            String refundId = "refund-123";
+            Long sellerId = scenario.seller.getId();
+            String rejectReason = "재고 부족으로 환불 불가";
+            RefundProcessRequestDto request = RefundTestFixture.createRejectRequest(rejectReason);
+
+            Refund refund = RefundTestFixture.createRefundWithItems(refundId, scenario.payment,
+                    RefundType.CHANGE_OF_MIND, "단순 변심", 15000, 1000, RefundStatus.INITIATED, scenario.orderItem);
+
+            given(refundRepository.findByIdWithDetails(refundId)).willReturn(Optional.of(refund));
+
+            // when
+            RefundProcessResponseDto result = refundService.processRefundRequest(sellerId, refundId, request);
+
+            // then
+            assertThat(result.refundId()).isEqualTo(refundId);
+            assertThat(result.status()).isEqualTo(RefundStatus.REJECTED);
+            assertThat(result.rejectReason()).isEqualTo(rejectReason);
+
+            // 환불 처리가 실행되지 않았는지 확인
+            verify(memberRepository, never()).increasePoints(anyLong(), anyInt());
+            verify(pointTransactionRepository, never()).save(any());
+            verify(groupBuyOptionRepository, never()).increaseStock(anyLong(), anyInt());
+        }
+
+        @Test
+        @DisplayName("실패 - 존재하지 않는 환불")
+        void processRefundRequest_refundNotFound_fail() {
+            // given
+            String refundId = "non-existent-refund";
+            Long sellerId = scenario.seller.getId();
+            RefundProcessRequestDto request = RefundTestFixture.createApproveRequest();
+
+            given(refundRepository.findByIdWithDetails(refundId)).willReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> refundService.processRefundRequest(sellerId, refundId, request))
+                    .isInstanceOf(BusinessException.class)
+                    .extracting(ex -> ((BusinessException) ex).getErrorCode())
+                    .isEqualTo(ErrorCode.REFUND_NOT_FOUND);
+        }
+
+        @Test
+        @DisplayName("실패 - 권한 없는 판매자")
+        void processRefundRequest_accessDenied_fail() {
+            // given
+            String refundId = "refund-123";
+            Long otherSellerId = 999L; // 다른 판매자
+            RefundProcessRequestDto request = RefundTestFixture.createApproveRequest();
+
+            Refund refund = RefundTestFixture.createRefundWithItems(refundId, scenario.payment,
+                    RefundType.CHANGE_OF_MIND, "단순 변심", 15000, 1000, RefundStatus.INITIATED, scenario.orderItem);
+
+            given(refundRepository.findByIdWithDetails(refundId)).willReturn(Optional.of(refund));
+
+            // when & then
+            assertThatThrownBy(() -> refundService.processRefundRequest(otherSellerId, refundId, request))
+                    .isInstanceOf(BusinessException.class)
+                    .extracting(ex -> ((BusinessException) ex).getErrorCode())
+                    .isEqualTo(ErrorCode.ACCESS_DENIED);
+        }
+
+        @Test
+        @DisplayName("실패 - 이미 처리된 환불")
+        void processRefundRequest_alreadyProcessed_fail() {
+            // given
+            String refundId = "refund-123";
+            Long sellerId = scenario.seller.getId();
+            RefundProcessRequestDto request = RefundTestFixture.createApproveRequest();
+
+            Refund refund = RefundTestFixture.createRefundWithItems(refundId, scenario.payment,
+                    RefundType.CHANGE_OF_MIND, "단순 변심", 15000, 1000, RefundStatus.APPROVED, scenario.orderItem); // 이미 승인됨
+
+            given(refundRepository.findByIdWithDetails(refundId)).willReturn(Optional.of(refund));
+
+            // when & then
+            assertThatThrownBy(() -> refundService.processRefundRequest(sellerId, refundId, request))
+                    .isInstanceOf(BusinessException.class)
+                    .extracting(ex -> ((BusinessException) ex).getErrorCode())
+                    .isEqualTo(ErrorCode.REFUND_ALREADY_PROCESSED);
+        }
+    }
+
+    private void setupBasicMocks() {
+        given(orderRepository.findById(eq("test-order-id")))
+                .willReturn(Optional.of(scenario.order));
+
+        // 더 명시적인 Mock 설정
+        given(paymentRepository.findByOrderId(eq("test-order-id")))
+                .willReturn(Optional.of(scenario.payment));
+
+        // 디버깅용 로그
+        System.out.println("Mocking Order ID: " + scenario.order.getId());
+        System.out.println("Mocking Payment: " + scenario.payment);
+    }
+}

--- a/src/test/java/com/ururulab/ururu/payment/service/RefundTestFixture.java
+++ b/src/test/java/com/ururulab/ururu/payment/service/RefundTestFixture.java
@@ -1,0 +1,285 @@
+package com.ururulab.ururu.payment.service;
+
+import com.ururulab.ururu.global.domain.entity.enumerated.Gender;
+import com.ururulab.ururu.groupBuy.domain.entity.GroupBuy;
+import com.ururulab.ururu.groupBuy.domain.entity.GroupBuyOption;
+import com.ururulab.ururu.member.domain.entity.Member;
+import com.ururulab.ururu.member.domain.entity.enumerated.Role;
+import com.ururulab.ururu.member.domain.entity.enumerated.SocialProvider;
+import com.ururulab.ururu.order.domain.entity.Order;
+import com.ururulab.ururu.order.domain.entity.OrderItem;
+import com.ururulab.ururu.order.domain.entity.enumerated.OrderStatus;
+import com.ururulab.ururu.payment.domain.entity.Payment;
+import com.ururulab.ururu.payment.domain.entity.Refund;
+import com.ururulab.ururu.payment.domain.entity.RefundItem;
+import com.ururulab.ururu.payment.domain.entity.enumerated.PaymentStatus;
+import com.ururulab.ururu.payment.domain.entity.enumerated.RefundStatus;
+import com.ururulab.ururu.payment.domain.entity.enumerated.RefundType;
+import com.ururulab.ururu.payment.dto.request.RefundProcessRequestDto;
+import com.ururulab.ururu.payment.dto.request.RefundRequestDto;
+import com.ururulab.ururu.product.domain.entity.Product;
+import com.ururulab.ururu.product.domain.entity.ProductOption;
+import com.ururulab.ururu.seller.domain.entity.Seller;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.time.LocalDate;
+
+public class RefundTestFixture {
+
+    public static Member createMember(Long id, String nickname, String email) {
+        Member member = Member.of(
+                nickname,
+                email,
+                SocialProvider.GOOGLE,
+                "social123",
+                Gender.FEMALE,
+                LocalDate.parse("1990-01-01"),
+                "01012345678",
+                "profile.jpg",
+                Role.NORMAL
+        );
+        setMemberId(member, id);
+        setMemberPoint(member, 5000);
+        return member;
+    }
+
+    public static Member createMember(Long id) {
+        return createMember(id, "testMember", "test@example.com");
+    }
+
+    public static Seller createSeller(Long id, String name) {
+        try {
+            Constructor<Seller> constructor = Seller.class.getDeclaredConstructor();
+            constructor.setAccessible(true);
+            Seller seller = constructor.newInstance();
+
+            Field idField = Seller.class.getDeclaredField("id");
+            idField.setAccessible(true);
+            idField.set(seller, id);
+
+            Field nameField = Seller.class.getDeclaredField("name");
+            nameField.setAccessible(true);
+            nameField.set(seller, name);
+
+            return seller;
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to create Seller for test", e);
+        }
+    }
+
+    public static Product createProduct(Long id, String name) {
+        try {
+            Constructor<Product> constructor = Product.class.getDeclaredConstructor();
+            constructor.setAccessible(true);
+            Product product = constructor.newInstance();
+
+            setFieldValue(product, "id", id);
+            setFieldValue(product, "name", name);
+
+            return product;
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to create Product for test", e);
+        }
+    }
+
+    public static ProductOption createProductOption(Long id, String name, Integer price, String imageUrl) {
+        try {
+            Constructor<ProductOption> constructor = ProductOption.class.getDeclaredConstructor();
+            constructor.setAccessible(true);
+            ProductOption option = constructor.newInstance();
+
+            setFieldValue(option, "id", id);
+            setFieldValue(option, "name", name);
+            setFieldValue(option, "price", price);
+            setFieldValue(option, "imageUrl", imageUrl);
+
+            return option;
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to create ProductOption for test", e);
+        }
+    }
+
+    public static GroupBuy createGroupBuy(Long id, Product product, Seller seller) {
+        try {
+            Constructor<GroupBuy> constructor = GroupBuy.class.getDeclaredConstructor();
+            constructor.setAccessible(true);
+            GroupBuy groupBuy = constructor.newInstance();
+
+            setFieldValue(groupBuy, "id", id);
+            setFieldValue(groupBuy, "product", product);
+            setFieldValue(groupBuy, "seller", seller);
+
+            return groupBuy;
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to create GroupBuy for test", e);
+        }
+    }
+
+    public static GroupBuyOption createGroupBuyOption(Long id, GroupBuy groupBuy, ProductOption productOption, Integer salePrice, Integer stock) {
+        try {
+            Constructor<GroupBuyOption> constructor = GroupBuyOption.class.getDeclaredConstructor();
+            constructor.setAccessible(true);
+            GroupBuyOption option = constructor.newInstance();
+
+            setFieldValue(option, "id", id);
+            setFieldValue(option, "groupBuy", groupBuy);
+            setFieldValue(option, "productOption", productOption);
+            setFieldValue(option, "salePrice", salePrice);
+            setFieldValue(option, "stock", stock);
+
+            return option;
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to create GroupBuyOption for test", e);
+        }
+    }
+
+    public static Order createOrder(String id, Member member, OrderStatus status) {
+        Order order = Order.create(member);
+        setFieldValue(order, "id", id);
+        setFieldValue(order, "status", status);
+
+        // 디버깅용 로그
+        System.out.println("Created Order with ID: " + id);
+
+        return order;
+    }
+
+    public static OrderItem createOrderItem(Long id, Order order, GroupBuyOption groupBuyOption, Integer quantity) {
+        OrderItem orderItem = OrderItem.create(groupBuyOption, quantity);
+        setFieldValue(orderItem, "id", id);
+        setFieldValue(orderItem, "order", order);
+        return orderItem;
+    }
+
+    public static Payment createPayment(Long id, Member member, Order order, Integer totalAmount, Integer amount, Integer point) {
+        Payment payment = Payment.create(member, order, totalAmount, amount, point);
+        setFieldValue(payment, "id", id);
+        setFieldValue(payment, "status", PaymentStatus.PAID);
+        return payment;
+    }
+
+    public static Refund createRefund(String id, Payment payment, RefundType type, String reason, Integer amount, Integer point, RefundStatus status) {
+        Refund refund = Refund.create(payment, type, reason, amount, point, "1234567890", status);
+        setFieldValue(refund, "id", id);
+        return refund;
+    }
+
+    public static Refund createRefundWithItems(String id, Payment payment, RefundType type, String reason,
+                                               Integer amount, Integer point, RefundStatus status, OrderItem orderItem) {
+        Refund refund = createRefund(id, payment, type, reason, amount, point, status);
+
+        // RefundItem 생성 및 추가
+        RefundItem refundItem = createRefundItem(1L, refund, orderItem);
+
+        // refundItems 리스트에 추가 (Reflection 사용)
+        try {
+            Field refundItemsField = Refund.class.getDeclaredField("refundItems");
+            refundItemsField.setAccessible(true);
+            @SuppressWarnings("unchecked")
+            java.util.List<RefundItem> refundItems = (java.util.List<RefundItem>) refundItemsField.get(refund);
+            refundItems.add(refundItem);
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to add RefundItem for test", e);
+        }
+
+        return refund;
+    }
+
+    public static RefundItem createRefundItem(Long id, Refund refund, OrderItem orderItem) {
+        RefundItem refundItem = RefundItem.create(orderItem);
+        setFieldValue(refundItem, "id", id);
+        setFieldValue(refundItem, "refund", refund);
+        return refundItem;
+    }
+
+    // Request DTOs
+    public static RefundRequestDto createChangeOfMindRequest() {
+        return new RefundRequestDto("CHANGE_OF_MIND", "단순 변심", "1234567890");
+    }
+
+    public static RefundProcessRequestDto createApproveRequest() {
+        return new RefundProcessRequestDto("APPROVE", null);
+    }
+
+    public static RefundProcessRequestDto createRejectRequest(String reason) {
+        return new RefundProcessRequestDto("REJECT", reason);
+    }
+
+    public static RefundTestScenario createCompleteScenario() {
+        Member member = createMember(1L);
+        Seller seller = createSeller(1L, "testSeller");
+        Product product = createProduct(1L, "테스트 상품");
+        ProductOption productOption = createProductOption(1L, "기본 옵션", 8000, "image.jpg");
+        GroupBuy groupBuy = createGroupBuy(1L, product, seller);
+        GroupBuyOption groupBuyOption = createGroupBuyOption(1L, groupBuy, productOption, 8000, 100);
+        Order order = createOrder("test-order-id", member, OrderStatus.ORDERED);
+        OrderItem orderItem = createOrderItem(1L, order, groupBuyOption, 2);
+
+        // 간단한 금액 설정: 상품 16000원, 포인트 1000원, 총 17000원
+        Payment payment = createPayment(1L, member, order, 17000, 16000, 1000);
+
+        // Order와 Payment의 연결 확실히 하기
+        setFieldValue(payment, "order", order);
+
+        return new RefundTestScenario(member, seller, product, productOption, groupBuy,
+                groupBuyOption, order, orderItem, payment);
+    }
+
+    // Helper methods
+    private static void setMemberId(Member member, Long id) {
+        setFieldValue(member, "id", id);
+    }
+
+    private static void setMemberPoint(Member member, Integer point) {
+        setFieldValue(member, "point", point);
+    }
+
+    private static void setFieldValue(Object target, String fieldName, Object value) {
+        try {
+            Field field = findField(target.getClass(), fieldName);
+            field.setAccessible(true);
+            field.set(target, value);
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to set field " + fieldName + " for test", e);
+        }
+    }
+
+    private static Field findField(Class<?> clazz, String fieldName) {
+        while (clazz != null) {
+            try {
+                return clazz.getDeclaredField(fieldName);
+            } catch (NoSuchFieldException e) {
+                clazz = clazz.getSuperclass();
+            }
+        }
+        throw new RuntimeException("Field " + fieldName + " not found");
+    }
+
+    // 테스트 시나리오를 담는 클래스
+    public static class RefundTestScenario {
+        public final Member member;
+        public final Seller seller;
+        public final Product product;
+        public final ProductOption productOption;
+        public final GroupBuy groupBuy;
+        public final GroupBuyOption groupBuyOption;
+        public final Order order;
+        public final OrderItem orderItem;
+        public final Payment payment;
+
+        public RefundTestScenario(Member member, Seller seller, Product product, ProductOption productOption,
+                                  GroupBuy groupBuy, GroupBuyOption groupBuyOption, Order order,
+                                  OrderItem orderItem, Payment payment) {
+            this.member = member;
+            this.seller = seller;
+            this.product = product;
+            this.productOption = productOption;
+            this.groupBuy = groupBuy;
+            this.groupBuyOption = groupBuyOption;
+            this.order = order;
+            this.orderItem = orderItem;
+            this.payment = payment;
+        }
+    }
+}


### PR DESCRIPTION
## ⭐️ Issue Number
- #117

## 🚩 Summary
- 수동 환불 요청 및 처리 API 전체 구현
  - `POST /api/orders/{orderId}/refund`: 환불 요청 생성
  - `PATCH /api/refunds/{refundId}`: 환불 승인/거절 처리
- 환불 타입별 기간 제한 및 자동 승인 로직 구현
- 포인트 복구, 재고 복구, 주문/결제 상태 업데이트 처리
- 판매자 권한 검증 및 중복 환불 방지 로직
- RefundServiceTest, RefundTestFixture 포함 테스트 코드 작성
## 🛠️ Technical Concerns
### 1. 운송장 등록 기준 자동 승인 로직
- 운송장 등록 전(`trackingRegisteredAt == null`)인 경우 즉시 자동 승인하여 환불 처리 완료
- 운송장 등록 후에는 환불 타입에 따라 기간 제한 적용: 단순변심 7일, 이외 사유 30일
- 자동 승인 시 포인트 복구, 재고 복구, PG 환불 요청까지 한 번에 처리
---
### 2. Order 단위 전체 환불 정책
- Order 단위 전체 환불만 지원
- `findRefundableItemsByOrderId`로 이미 환불된 아이템 제외하고 환불 가능한 아이템만 조회
- 환불 금액은 상품 금액과 포인트를 분리하여 각각 계산 및 복구 처리
---
### 3. 포괄적인 환불 처리 플로우
- **포인트 복구**: `memberRepository.increasePoints` + `PointTransaction` 기록
- **재고 복구**: `groupBuyOptionRepository.increaseStock`로 옵션별 수량 복구
- **상태 업데이트**: Order → `REFUNDED`, Payment → `REFUNDED`
- **PG 환불**: 토스페이먼츠 환불 API 연동 준비 (TODO에서 완료 예정)

## 🙂 To Reviewer
- `운송장 등록 전후 자동 승인` 로직이 실제 비즈니스 요구사항과 일치하는지 검토 요청
- 환불 처리 시 `포인트 복구 → 재고 복구 → 상태 업데이트 → PG 환불` 순서가 올바른지 검토 요청
- RefundService의 비즈니스 로직이 너무 복잡하지 않고 책임이 적절히 분리되어 있는지 검토 요청
- [환불 시스템 시나리오 분석](https://www.notion.so/226b87f310fe80209500d5515002e989?source=copy_link)를 참고해주세요. 체크를 계속해도 예외 이슈나 엣지 케이스가 너무 많아서 놓친 부분이 있을 수 있어요..... 검토 부탁드립니다

## 📋 To Do
- [ ] 주문/배송 내역 조회에 환불 가능 날짜를 반환해주는 기능 추가
- [ ] 자동 환불 처리 추가 (작성 중)
- [ ] PG 연결 (테스트 중)