### PR TITLE
Grafana Loki 로그 집계 시스템 구축

### DIFF
--- a/docker/docker-compose-monitoring.yml
+++ b/docker/docker-compose-monitoring.yml
@@ -19,6 +19,29 @@ services:
       - '--storage.tsdb.retention.time=200h'
       - '--web.enable-lifecycle'
 
+  # Loki (로그 수집)
+  loki:
+    image: grafana/loki:latest
+    container_name: ururu-loki
+    restart: unless-stopped
+    ports:
+      - "3100:3100"
+    volumes:
+      - ./monitoring/loki/local-config.yml:/etc/loki/local-config.yml:ro
+      - loki_data:/loki
+    command: -config.file=/etc/loki/local-config.yml
+
+  # Promtail (로그 수집기)
+  promtail:
+    image: grafana/promtail:latest
+    container_name: ururu-promtail
+    restart: unless-stopped
+    volumes:
+      - ./monitoring/promtail/config.yml:/etc/promtail/config.yml:ro
+      - /var/log:/var/log:ro
+      - /app/logs:/app/logs:ro
+    command: -config.file=/etc/promtail/config.yml
+
   # Grafana (대시보드)
   grafana:
     image: grafana/grafana:latest
@@ -42,4 +65,5 @@ services:
 
 volumes:
   prometheus_data:
-  grafana_data: 
+  grafana_data:
+  loki_data: 

--- a/docker/monitoring/grafana/provisioning/datasources/datasources.yml
+++ b/docker/monitoring/grafana/provisioning/datasources/datasources.yml
@@ -9,4 +9,12 @@ datasources:
     editable: true
     jsonData:
       timeInterval: "15s"
-    secureJsonData: {} 
+    secureJsonData: {}
+
+  - name: Loki
+    type: loki
+    access: proxy
+    url: http://loki:3100
+    editable: true
+    jsonData:
+      maxLines: 1000 

--- a/docker/monitoring/loki/local-config.yml
+++ b/docker/monitoring/loki/local-config.yml
@@ -1,0 +1,49 @@
+auth_enabled: false
+
+server:
+  http_listen_port: 3100
+
+ingester:
+  lifecycler:
+    address: 127.0.0.1
+    ring:
+      kvstore:
+        store: inmemory
+      replication_factor: 1
+    finalize_ring: false
+  chunk_idle_period: 5m
+  chunk_retain_period: 30s
+
+schema_config:
+  configs:
+    - from: 2020-05-15
+      store: boltdb-shipper
+      object_store: filesystem
+      schema: v11
+      index:
+        prefix: index_
+        period: 24h
+
+storage_config:
+  boltdb_shipper:
+    active_index_directory: /loki/boltdb-shipper-active
+    cache_location: /loki/boltdb-shipper-cache
+    cache_ttl: 24h
+    shared_store: filesystem
+  filesystem:
+    directory: /loki/chunks
+
+compactor:
+  working_directory: /loki/compactor
+  shared_store: filesystem
+
+limits_config:
+  reject_old_samples: true
+  reject_old_samples_max_age: 168h
+
+chunk_store_config:
+  max_look_back_period: 0s
+
+table_manager:
+  retention_deletes_enabled: false
+  retention_period: 0s 

--- a/docker/monitoring/promtail/config.yml
+++ b/docker/monitoring/promtail/config.yml
@@ -1,0 +1,26 @@
+server:
+  http_listen_port: 9080
+  grpc_listen_port: 0
+
+positions:
+  filename: /tmp/positions.yaml
+
+clients:
+  - url: http://loki:3100/loki/api/v1/push
+
+scrape_configs:
+  - job_name: ururu-backend
+    static_configs:
+      - targets:
+          - localhost
+        labels:
+          job: ururu-backend
+          __path__: /app/logs/ururu-backend.log
+
+  - job_name: system-logs
+    static_configs:
+      - targets:
+          - localhost
+        labels:
+          job: system-logs
+          __path__: /var/log/*.log 


### PR DESCRIPTION
## ⭐️ Issue Number
- #184 

## 🚩 Summary

- Loki와 Promtail을 통한 중앙화된 로깅 시스템 구축
- Grafana에서 메트릭(Prometheus)과 로그(Loki)를 통합하여 모니터링 가능
- 애플리케이션 로깅 설정을 Loki 호환성으로 개선하여 구조화된 로그 분석 지원
- 로그 로테이션 및 보존 정책 설정으로 디스크 공간 효율적 관리

## 🛠️ Technical Concerns

- Docker Compose 설정: Loki, Promtail 서비스를 docker-compose-monitoring.yml에 추가
- 로그 수집 경로: Promtail이 /app/logs/ururu-backend.log에서 로그를 수집하도록 설정
- Grafana 데이터소스: Loki 데이터소스를 추가하여 로그 쿼리 및 시각화 가능
- 애플리케이션 로깅: application-prod.yml에 파일 로깅 설정 추가 (100MB 단위 로테이션, 30일 보존)
- 타임스탬프 정밀도: 밀리초 단위 타임스탬프로 정확한 로그 분석 지원

## 🙂 To Reviewer
@songcw8 
Loki와 Promtail 설정이 올바르게 구성되었는지 확인 부탁드립니다
애플리케이션 로깅 설정이 운영환경에서 정상 동작할지 검토 부탁드립니다

## 📋 To Do

- [ ] 운영환경 배포 후 Loki/Promtail 서비스 정상 동작 확인
- [ ] Grafana에서 로그 쿼리 및 시각화 테스트