### PR TITLE
회원 탈퇴 로직 수정

### DIFF
--- a/src/main/java/com/ururulab/ururu/global/exception/error/ErrorCode.java
+++ b/src/main/java/com/ururulab/ururu/global/exception/error/ErrorCode.java
@@ -216,6 +216,8 @@ public enum ErrorCode {
 	PROFILE_IMAGE_REQUIRED(HttpStatus.BAD_REQUEST, "MEMBER009", "이미지 파일은 필수입니다."),
 	INVALID_GENDER_VALUE(HttpStatus.BAD_REQUEST, "MEMBER010", "올바른 성별 값이 아닙니다."),
 	MEMBER_DELETION_FAILED(HttpStatus.BAD_REQUEST, "MEMBER011", "회원 데이터 정리 중 오류가 발생했습니다"),
+	MEMBER_DELETED(HttpStatus.BAD_REQUEST, "MEMBER012", "탈퇴한 회원입니다."),
+	MEMBER_LOGIN_DENIED(HttpStatus.BAD_REQUEST,"MEMBER013", "탈퇴한 회원은 로그인할 수 없습니다."),
 
 	// --- 뷰티 프로필 ---
 	BEAUTY_PROFILE_NOT_FOUND(HttpStatus.NOT_FOUND, "BEAUTY001", "뷰티 프로필을 찾을 수 없습니다."),

--- a/src/main/java/com/ururulab/ururu/member/domain/repository/MemberPreferenceRepository.java
+++ b/src/main/java/com/ururulab/ururu/member/domain/repository/MemberPreferenceRepository.java
@@ -10,4 +10,5 @@ import java.util.List;
 public interface MemberPreferenceRepository extends JpaRepository<MemberPreference, Long> {
     List<MemberPreference> findByMemberId(Long memberId);
     boolean existsByMemberIdAndSellerId(Long memberId, Long sellerId);
+    void deleteByMemberId(Long memberId);
 }

--- a/src/main/java/com/ururulab/ururu/member/domain/repository/MemberPreferenceRepository.java
+++ b/src/main/java/com/ururulab/ururu/member/domain/repository/MemberPreferenceRepository.java
@@ -10,5 +10,4 @@ import java.util.List;
 public interface MemberPreferenceRepository extends JpaRepository<MemberPreference, Long> {
     List<MemberPreference> findByMemberId(Long memberId);
     boolean existsByMemberIdAndSellerId(Long memberId, Long sellerId);
-    void deleteByMemberId(Long memberId);
 }

--- a/src/main/java/com/ururulab/ururu/member/service/MemberService.java
+++ b/src/main/java/com/ururulab/ururu/member/service/MemberService.java
@@ -45,10 +45,19 @@ public class MemberService {
 
     @Transactional
     public Member findOrCreateMember(final SocialMemberInfo socialMemberInfo) {
-        return memberRepository.findBySocialProviderAndSocialId(
+        Optional<Member> existingMember = memberRepository.findBySocialProviderAndSocialId(
                 socialMemberInfo.provider(),
                 socialMemberInfo.socialId()
-        ).orElseGet(() -> createNewMember(socialMemberInfo));
+        );
+        if (existingMember.isPresent()) {
+            Member member = existingMember.get();
+            if (member.isDeleted()) {
+                throw new BusinessException(ErrorCode.MEMBER_DELETED, "탈퇴한 회원은 로그인할 수 없습니다.");
+            }
+            return member;
+        } else {
+            return createNewMember(socialMemberInfo);
+        }
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/ururulab/ururu/member/service/MemberService.java
+++ b/src/main/java/com/ururulab/ururu/member/service/MemberService.java
@@ -45,19 +45,12 @@ public class MemberService {
 
     @Transactional
     public Member findOrCreateMember(final SocialMemberInfo socialMemberInfo) {
-        Optional<Member> existingMember = memberRepository.findBySocialProviderAndSocialId(
-                socialMemberInfo.provider(),
-                socialMemberInfo.socialId()
-        );
-        if (existingMember.isPresent()) {
-            Member member = existingMember.get();
-            if (member.isDeleted()) {
-                throw new BusinessException(ErrorCode.MEMBER_DELETED, "탈퇴한 회원은 로그인할 수 없습니다.");
-            }
-            return member;
-        } else {
-            return createNewMember(socialMemberInfo);
-        }
+        return memberRepository.findBySocialProviderAndSocialId(
+                        socialMemberInfo.provider(),
+                        socialMemberInfo.socialId()
+                )
+                .filter(member -> !member.isDeleted())
+                .orElseGet(() -> createNewMember(socialMemberInfo));
     }
 
     @Transactional(readOnly = true)


### PR DESCRIPTION
## ⭐️ Issue Number
- #186

## 🚩 Summary
- 회원탈퇴 로직 수정
    - 최소한의 검증만 실행하고 소프트 삭제로 변경

## 🛠️ Technical Concerns
- 원래는 탈퇴하는 회원과 관련된 모든 데이터를 삭제한 후 회원 데이터도 하드삭제하려고 했지만, 트랜젝션 롤백문제가 여러번 발생해 소프트 삭제로 변경하였습니다.

## 🙂 To Reviewer
- 회원 탈퇴가 잘 되는지만 확인해주시면 감사하겠습니다!

## 📋 To Do
- 회원 탈퇴 프론트 연동 마무리

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **버그 수정**
  * 회원 탈퇴 시 일부 세부 검증 및 데이터 정리 단계가 간소화되어, 활성 주문이 없을 경우에만 탈퇴가 가능하도록 변경되었습니다.
  * 탈퇴 시 관련 데이터 정리는 추후 배치 처리로 안내됩니다.
  * 탈퇴한 회원은 로그인할 수 없도록 제한하는 기능이 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->