### PR TITLE
주문/배송 내역 환불 정보 표시 및 무료 배송 적용, 쿼리 최적화

### DIFF
--- a/src/main/java/com/ururulab/ururu/order/domain/repository/OrderRepository.java
+++ b/src/main/java/com/ururulab/ururu/order/domain/repository/OrderRepository.java
@@ -10,7 +10,7 @@ import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
-public interface OrderRepository extends JpaRepository<Order, String> {
+public interface OrderRepository extends JpaRepository<Order, String>, OrderRepositoryCustom {
 
     /**
      * 특정 회원의 PENDING 상태 주문들 조회
@@ -21,77 +21,6 @@ public interface OrderRepository extends JpaRepository<Order, String> {
 
     @Query("SELECT COUNT(o) FROM Order o WHERE o.member.id = :memberId AND o.status IN ('PENDING', 'ORDERED')")
     int countActiveOrdersByMemberId(@Param("memberId") Long memberId);
-
-    /**
-     * 진행중 공구의 주문 목록 조회 (연관 엔티티 페치조인)
-     */
-    @Query("SELECT DISTINCT o FROM Order o " +
-            "LEFT JOIN FETCH o.orderItems oi " +
-            "LEFT JOIN FETCH oi.groupBuyOption gbo " +
-            "LEFT JOIN FETCH gbo.groupBuy gb " +
-            "LEFT JOIN FETCH gb.product p " +
-            "LEFT JOIN FETCH gbo.productOption po " +
-            "WHERE o.member.id = :memberId " +
-            "AND o.status IN ('ORDERED', 'PARTIAL_REFUNDED') " +
-            "AND gb.status = 'OPEN' " +
-            "AND NOT EXISTS (" +
-            "  SELECT 1 FROM RefundItem ri " +
-            "  JOIN ri.refund r " +
-            "  WHERE ri.orderItem.id = oi.id " +
-            "  AND r.status IN ('APPROVED', 'COMPLETED')" +
-            ") " +
-            "ORDER BY o.createdAt DESC")
-    Page<Order> findInProgressOrdersWithDetails(
-            @Param("memberId") Long memberId,
-            Pageable pageable
-    );
-
-    /**
-     * 확정된 공구의 주문 목록 조회 (연관 엔티티 페치조인)
-     */
-    @Query("SELECT DISTINCT o FROM Order o " +
-            "LEFT JOIN FETCH o.orderItems oi " +
-            "LEFT JOIN FETCH oi.groupBuyOption gbo " +
-            "LEFT JOIN FETCH gbo.groupBuy gb " +
-            "LEFT JOIN FETCH gb.product p " +
-            "LEFT JOIN FETCH gbo.productOption po " +
-            "WHERE o.member.id = :memberId " +
-            "AND o.status IN ('ORDERED', 'PARTIAL_REFUNDED') " +
-            "AND gb.status = 'CLOSED' " +
-            "AND NOT EXISTS (" +
-            "  SELECT 1 FROM RefundItem ri " +
-            "  JOIN ri.refund r " +
-            "  WHERE ri.orderItem.id = oi.id " +
-            "  AND r.status IN ('APPROVED', 'COMPLETED')" +
-            ") " +
-            "ORDER BY o.createdAt DESC")
-    Page<Order> findConfirmedOrdersWithDetails(
-            @Param("memberId") Long memberId,
-            Pageable pageable
-    );
-
-    /**
-     * 환불 대기중 주문 목록 조회 (연관 엔티티 페치조인)
-     */
-    @Query("SELECT DISTINCT o FROM Order o " +
-            "LEFT JOIN FETCH o.orderItems oi " +
-            "LEFT JOIN FETCH oi.groupBuyOption gbo " +
-            "LEFT JOIN FETCH gbo.groupBuy gb " +
-            "LEFT JOIN FETCH gb.product p " +
-            "LEFT JOIN FETCH gbo.productOption po " +
-            "WHERE o.member.id = :memberId " +
-            "AND o.status IN ('ORDERED', 'PARTIAL_REFUNDED') " +
-            "AND EXISTS (" +
-            "  SELECT 1 FROM RefundItem ri " +
-            "  JOIN ri.refund r " +
-            "  WHERE ri.orderItem.id = oi.id " +
-            "  AND r.status = 'INITIATED'" +
-            ") " +
-            "ORDER BY o.createdAt DESC")
-    Page<Order> findRefundPendingOrdersWithDetails(
-            @Param("memberId") Long memberId,
-            Pageable pageable
-    );
 
     /**
      * 전체 주문 목록 조회 (연관 엔티티 페치조인)

--- a/src/main/java/com/ururulab/ururu/order/domain/repository/OrderRepositoryCustom.java
+++ b/src/main/java/com/ururulab/ururu/order/domain/repository/OrderRepositoryCustom.java
@@ -1,0 +1,28 @@
+package com.ururulab.ururu.order.domain.repository;
+
+import com.ururulab.ururu.order.domain.entity.Order;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface OrderRepositoryCustom {
+
+    /**
+     * 회원의 주문 목록을 상태별로 조회합니다.
+     * 환불되지 않은 OrderItem이 있는 주문만 반환합니다.
+     *
+     * @param memberId 회원 ID
+     * @param statusFilter 상태 필터 ("inprogress", "confirmed", "refundpending", "all")
+     * @param pageable 페이징 정보
+     * @return 페이징된 주문 목록
+     */
+    Page<Order> findMyOrdersWithDetails(Long memberId, String statusFilter, Pageable pageable);
+
+    /**
+     * 회원의 주문 개수를 상태별로 조회합니다.
+     *
+     * @param memberId 회원 ID
+     * @param statusFilter 상태 필터
+     * @return 주문 개수
+     */
+    Long countMyOrders(Long memberId, String statusFilter);
+}

--- a/src/main/java/com/ururulab/ururu/order/domain/repository/OrderRepositoryImpl.java
+++ b/src/main/java/com/ururulab/ururu/order/domain/repository/OrderRepositoryImpl.java
@@ -1,0 +1,189 @@
+package com.ururulab.ururu.order.domain.repository;
+
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.JPAExpressions;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.ururulab.ururu.groupBuy.domain.entity.enumerated.GroupBuyStatus;
+import com.ururulab.ururu.order.domain.entity.Order;
+import com.ururulab.ururu.order.domain.entity.enumerated.OrderStatus;
+import com.ururulab.ururu.payment.domain.entity.enumerated.RefundStatus;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+import com.ururulab.ururu.order.domain.entity.QOrder;
+import com.ururulab.ururu.order.domain.entity.QOrderItem;
+import com.ururulab.ururu.groupBuy.domain.entity.QGroupBuyOption;
+import com.ururulab.ururu.groupBuy.domain.entity.QGroupBuy;
+import com.ururulab.ururu.product.domain.entity.QProduct;
+import com.ururulab.ururu.payment.domain.entity.QRefundItem;
+import com.ururulab.ururu.payment.domain.entity.QRefund;
+
+@Repository
+@RequiredArgsConstructor
+public class OrderRepositoryImpl implements OrderRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    /**
+     * 회원의 주문 목록을 상태별로 조회합니다.
+     * 환불되지 않은 OrderItem이 있는 주문만 반환합니다.
+     *
+     * @param memberId 회원 ID
+     * @param statusFilter 상태 필터 ("inprogress", "confirmed", "refundpending", "all")
+     * @param pageable 페이징 정보
+     * @return 페이징된 주문 목록
+     */
+    @Override
+    public Page<Order> findMyOrdersWithDetails(Long memberId, String statusFilter, Pageable pageable) {
+        QOrder order = QOrder.order;
+        QOrderItem orderItem = QOrderItem.orderItem;
+        QGroupBuyOption groupBuyOption = QGroupBuyOption.groupBuyOption;
+        QGroupBuy groupBuy = QGroupBuy.groupBuy;
+        QProduct product = QProduct.product;
+
+        BooleanBuilder builder = buildWhereConditions(memberId, statusFilter);
+
+        // 데이터 조회
+        List<Order> orders = queryFactory
+                .selectFrom(order)
+                .distinct()
+                .leftJoin(order.orderItems, orderItem).fetchJoin()
+                .leftJoin(orderItem.groupBuyOption, groupBuyOption).fetchJoin()
+                .leftJoin(groupBuyOption.groupBuy, groupBuy).fetchJoin()
+                .leftJoin(groupBuy.product, product).fetchJoin()
+                .leftJoin(groupBuyOption.productOption).fetchJoin()  // 직접 조인
+                .where(builder)
+                .orderBy(order.createdAt.desc())
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+
+        // 카운트 조회
+        Long total = countMyOrders(memberId, statusFilter);
+
+        return new PageImpl<>(orders, pageable, total);
+    }
+
+    /**
+     * 회원의 주문 개수를 상태별로 조회합니다.
+     *
+     * @param memberId 회원 ID
+     * @param statusFilter 상태 필터
+     * @return 주문 개수
+     */
+    @Override
+    public Long countMyOrders(Long memberId, String statusFilter) {
+        QOrder order = QOrder.order;
+        QOrderItem orderItem = QOrderItem.orderItem;
+        QGroupBuyOption groupBuyOption = QGroupBuyOption.groupBuyOption;
+        QGroupBuy groupBuy = QGroupBuy.groupBuy;
+
+        BooleanBuilder builder = buildWhereConditions(memberId, statusFilter);
+
+        return queryFactory
+                .select(order.countDistinct())
+                .from(order)
+                .join(order.orderItems, orderItem)
+                .join(orderItem.groupBuyOption, groupBuyOption)
+                .join(groupBuyOption.groupBuy, groupBuy)
+                .where(builder)
+                .fetchOne();
+    }
+
+    /**
+     * 상태별 WHERE 조건을 구성합니다.
+     */
+    private BooleanBuilder buildWhereConditions(Long memberId, String statusFilter) {
+        QOrder order = QOrder.order;
+        QOrderItem orderItem = QOrderItem.orderItem;
+        QGroupBuy groupBuy = QGroupBuy.groupBuy;
+
+        BooleanBuilder builder = new BooleanBuilder();
+
+        // 공통 조건
+        builder.and(order.member.id.eq(memberId))
+                .and(order.status.in(OrderStatus.ORDERED, OrderStatus.PARTIAL_REFUNDED))
+                .and(hasNonRefundedItems(order));
+
+        // 상태별 조건
+        switch (statusFilter.toLowerCase()) {
+            case "inprogress" ->
+                builder.and(groupBuy.status.eq(GroupBuyStatus.OPEN))
+                        .and(hasNoApprovedOrCompletedRefund(orderItem));
+
+            case "confirmed" ->
+                builder.and(groupBuy.status.eq(GroupBuyStatus.CLOSED))
+                        .and(hasNoApprovedOrCompletedRefund(orderItem));
+            case "refundpending" ->
+                builder.and(hasInitiatedRefund(orderItem));
+            // "all"은 추가 조건 없음 (환불되지 않은 아이템이 있는 조건만)
+        }
+
+        return builder;
+    }
+
+    /**
+     * 환불되지 않은 OrderItem이 하나라도 있는지 확인합니다.
+     */
+    private BooleanExpression hasNonRefundedItems(QOrder order) {
+        QOrderItem oi2 = new QOrderItem("subOrderItem");
+        QRefundItem refundItem = QRefundItem.refundItem;
+        QRefund refund = QRefund.refund;
+
+        return JPAExpressions
+                .selectOne()
+                .from(oi2)
+                .where(oi2.order.eq(order)
+                        .and(JPAExpressions
+                                .selectOne()
+                                .from(refundItem)
+                                .join(refundItem.refund, refund)
+                                .where(refundItem.orderItem.eq(oi2)
+                                        .and(refund.status.in(
+                                                RefundStatus.APPROVED,
+                                                RefundStatus.COMPLETED,
+                                                RefundStatus.FAILED,
+                                                RefundStatus.REJECTED)))
+                                .notExists()))
+                .exists();
+    }
+
+    /**
+     * APPROVED 또는 COMPLETED 상태의 환불이 없는지 확인합니다.
+     * (기존 로직과 동일)
+     */
+    private BooleanExpression hasNoApprovedOrCompletedRefund(QOrderItem orderItem) {
+        QRefundItem refundItem = QRefundItem.refundItem;
+        QRefund refund = QRefund.refund;
+
+        return JPAExpressions
+                .selectOne()
+                .from(refundItem)
+                .join(refundItem.refund, refund)
+                .where(refundItem.orderItem.eq(orderItem)
+                        .and(refund.status.in(RefundStatus.APPROVED, RefundStatus.COMPLETED)))
+                .notExists();
+    }
+
+    /**
+     * INITIATED 상태의 환불이 있는지 확인합니다.
+     */
+    private BooleanExpression hasInitiatedRefund(QOrderItem orderItem) {
+        QRefundItem refundItem = QRefundItem.refundItem;
+        QRefund refund = QRefund.refund;
+
+        return JPAExpressions
+                .selectOne()
+                .from(refundItem)
+                .join(refundItem.refund, refund)
+                .where(refundItem.orderItem.eq(orderItem)
+                        .and(refund.status.eq(RefundStatus.INITIATED)))
+                .exists();
+    }
+}

--- a/src/main/java/com/ururulab/ururu/order/dto/response/MyOrderResponseDto.java
+++ b/src/main/java/com/ururulab/ururu/order/dto/response/MyOrderResponseDto.java
@@ -1,9 +1,12 @@
 package com.ururulab.ururu.order.dto.response;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.ururulab.ururu.payment.domain.entity.enumerated.RefundType;
+
 import java.time.Instant;
 import java.util.List;
 
-
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public record MyOrderResponseDto(
         String orderId,
         Instant createdAt,
@@ -11,6 +14,8 @@ public record MyOrderResponseDto(
         Integer totalAmount,
         Boolean canRefundChangeOfMind,
         Boolean canRefundOthers,
+        RefundType refundType,     // 환불 INIT 경우
+        String refundReason,       // 환불 INIT 경우
         List<OrderItemResponseDto> orderItems
 ) {
 }

--- a/src/main/java/com/ururulab/ururu/order/service/MyOrderService.java
+++ b/src/main/java/com/ururulab/ururu/order/service/MyOrderService.java
@@ -18,9 +18,11 @@ import com.ururulab.ururu.order.dto.response.MyOrderListResponseDto;
 import com.ururulab.ururu.order.dto.response.MyOrderResponseDto;
 import com.ururulab.ururu.order.dto.response.OrderItemResponseDto;
 import com.ururulab.ururu.payment.domain.entity.Payment;
+import com.ururulab.ururu.payment.domain.entity.Refund;
 import com.ururulab.ururu.payment.domain.entity.enumerated.RefundStatus;
 import com.ururulab.ururu.payment.domain.repository.PaymentRepository;
 import com.ururulab.ururu.payment.domain.repository.RefundItemRepository;
+import com.ururulab.ururu.payment.domain.repository.RefundRepository;
 import com.ururulab.ururu.product.domain.entity.ProductOption;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -46,6 +48,7 @@ public class MyOrderService {
     private final PaymentRepository paymentRepository;
     private final MemberRepository memberRepository;
     private final GroupBuyStatisticsRepository groupBuyStatisticsRepository;
+    private final RefundRepository refundRepository;
     private final RefundItemRepository refundItemRepository;
     private final ObjectMapper objectMapper;
 
@@ -162,6 +165,8 @@ public class MyOrderService {
         Boolean canRefundChangeOfMind = refundStatus[0];
         Boolean canRefundOthers = refundStatus[1];
 
+        Optional<Refund> activeRefund = refundRepository.findActiveRefundByOrderId(order.getId());
+
         return new MyOrderResponseDto(
                 order.getId(),
                 order.getCreatedAt(),
@@ -169,6 +174,8 @@ public class MyOrderService {
                 totalAmount,
                 canRefundChangeOfMind,
                 canRefundOthers,
+                activeRefund.map(Refund::getType).orElse(null),
+                activeRefund.map(Refund::getReason).orElse(null),
                 orderItems
         );
     }

--- a/src/main/java/com/ururulab/ururu/order/service/OrderCreationService.java
+++ b/src/main/java/com/ururulab/ururu/order/service/OrderCreationService.java
@@ -404,13 +404,13 @@ public class OrderCreationService {
 
     /**
      * 배송비 계산
-     * 현재는 일괄 3000원 고정 적용
+     * 현재는 일괄 무료 배송 고정 적용
      *
      * @param totalAmount 총 주문 금액 (현재 미사용)
-     * @return 배송비 (3000원 고정)
+     * @return 배송비 (0원)
      */
     private Integer calculateShippingFee(Integer totalAmount) {
-        return 3000;
+        return 0;
     }
 
     /**

--- a/src/main/java/com/ururulab/ururu/payment/domain/repository/RefundRepository.java
+++ b/src/main/java/com/ururulab/ururu/payment/domain/repository/RefundRepository.java
@@ -99,4 +99,15 @@ public interface RefundRepository extends JpaRepository<Refund, String> {
             "JOIN r.payment p " +
             "WHERE p.order.id = :orderId")
     List<Refund> findByOrderId(@Param("orderId") String orderId);
+
+    /**
+     * 특정 주문에 대한 현재 진행중인 환불 정보를 조회합니다.
+     *
+     * @param orderId 주문 ID
+     * @return 진행중인 환불 정보 (INITIATED 상태), 없으면 Optional.empty()
+     */
+    @Query("SELECT r FROM Refund r " +
+            "WHERE r.payment.order.id = :orderId " +
+            "AND r.status = 'INITIATED'")
+    Optional<Refund> findActiveRefundByOrderId(@Param("orderId") String orderId);
 }

--- a/src/main/java/com/ururulab/ururu/payment/service/PaymentService.java
+++ b/src/main/java/com/ururulab/ururu/payment/service/PaymentService.java
@@ -52,7 +52,7 @@
     @Transactional(readOnly = true)
     public class PaymentService {
 
-        private static final Integer SHIPPING_FEE = 3000; // 배송비 고정
+        private static final Integer SHIPPING_FEE = 0; // 배송비 고정
         private static final String TOSS_PAYMENT_STATUS_CHANGED = "PAYMENT_STATUS_CHANGED"; // 토스 웹훅 이벤트 타입
         private static final String DONE = "DONE"; // Toss 결제 상태가 완료인 경우
 

--- a/src/test/java/com/ururulab/ururu/order/service/MyOrderServiceTest.java
+++ b/src/test/java/com/ururulab/ururu/order/service/MyOrderServiceTest.java
@@ -27,6 +27,7 @@ import com.ururulab.ururu.payment.domain.entity.Payment;
 import com.ururulab.ururu.payment.domain.entity.enumerated.RefundStatus;
 import com.ururulab.ururu.payment.domain.repository.PaymentRepository;
 import com.ururulab.ururu.payment.domain.repository.RefundItemRepository;
+import com.ururulab.ururu.payment.domain.repository.RefundRepository;
 import com.ururulab.ururu.product.domain.entity.Product;
 import com.ururulab.ururu.product.domain.entity.ProductOption;
 import org.junit.jupiter.api.BeforeEach;
@@ -73,6 +74,9 @@ class MyOrderServiceTest {
 
     @Mock
     private GroupBuyStatisticsRepository groupBuyStatisticsRepository;
+
+    @Mock
+    private RefundRepository refundRepository;
 
     @Mock
     private RefundItemRepository refundItemRepository;

--- a/src/test/java/com/ururulab/ururu/order/service/MyOrderServiceTest.java
+++ b/src/test/java/com/ururulab/ururu/order/service/MyOrderServiceTest.java
@@ -21,8 +21,6 @@ import com.ururulab.ururu.order.domain.entity.enumerated.OrderStatus;
 import com.ururulab.ururu.order.domain.repository.OrderItemRepository;
 import com.ururulab.ururu.order.domain.repository.OrderRepository;
 import com.ururulab.ururu.order.dto.response.MyOrderListResponseDto;
-import com.ururulab.ururu.order.dto.response.MyOrderResponseDto;
-import com.ururulab.ururu.order.dto.response.OrderItemResponseDto;
 import com.ururulab.ururu.payment.domain.entity.Payment;
 import com.ururulab.ururu.payment.domain.entity.enumerated.RefundStatus;
 import com.ururulab.ururu.payment.domain.repository.PaymentRepository;
@@ -113,10 +111,10 @@ class MyOrderServiceTest {
             Page<Order> orderPage = new PageImpl<>(List.of(testOrder));
 
             given(memberRepository.existsById(MEMBER_ID)).willReturn(true);
-            given(orderRepository.countInProgressOrders(MEMBER_ID)).willReturn(1L);
-            given(orderRepository.countConfirmedOrders(MEMBER_ID)).willReturn(0L);
-            given(orderRepository.countRefundPendingOrders(MEMBER_ID)).willReturn(0L);
-            given(orderRepository.findInProgressOrdersWithDetails(eq(MEMBER_ID), any(Pageable.class)))
+            given(orderRepository.countMyOrders(MEMBER_ID, "inprogress")).willReturn(1L);
+            given(orderRepository.countMyOrders(MEMBER_ID, "confirmed")).willReturn(0L);
+            given(orderRepository.countMyOrders(MEMBER_ID, "refundpending")).willReturn(0L);
+            given(orderRepository.findMyOrdersWithDetails(eq(MEMBER_ID), eq("inprogress"), any(Pageable.class)))
                     .willReturn(orderPage);
             given(refundItemRepository.existsByOrderItemIdAndRefundStatusIn(anyLong(), any())).willReturn(false);
             given(paymentRepository.findByOrderId(ORDER_ID)).willReturn(Optional.of(testPayment));
@@ -131,7 +129,7 @@ class MyOrderServiceTest {
 
             // then
             assertThat(result.orders()).hasSize(1);
-            verify(orderRepository).findInProgressOrdersWithDetails(eq(MEMBER_ID), any(Pageable.class));
+            verify(orderRepository).findMyOrdersWithDetails(eq(MEMBER_ID), eq("inprogress"), any(Pageable.class));
         }
 
         @Test
@@ -141,10 +139,10 @@ class MyOrderServiceTest {
             Page<Order> orderPage = new PageImpl<>(List.of(testOrder));
 
             given(memberRepository.existsById(MEMBER_ID)).willReturn(true);
-            given(orderRepository.countInProgressOrders(MEMBER_ID)).willReturn(0L);
-            given(orderRepository.countConfirmedOrders(MEMBER_ID)).willReturn(1L);
-            given(orderRepository.countRefundPendingOrders(MEMBER_ID)).willReturn(0L);
-            given(orderRepository.findConfirmedOrdersWithDetails(eq(MEMBER_ID), any(Pageable.class)))
+            given(orderRepository.countMyOrders(MEMBER_ID, "inprogress")).willReturn(0L);
+            given(orderRepository.countMyOrders(MEMBER_ID, "confirmed")).willReturn(1L);
+            given(orderRepository.countMyOrders(MEMBER_ID, "refundpending")).willReturn(0L);
+            given(orderRepository.findMyOrdersWithDetails(eq(MEMBER_ID), eq("confirmed"), any(Pageable.class)))
                     .willReturn(orderPage);
             given(refundItemRepository.existsByOrderItemIdAndRefundStatusIn(anyLong(), any())).willReturn(false);
             given(paymentRepository.findByOrderId(ORDER_ID)).willReturn(Optional.of(testPayment));
@@ -159,7 +157,7 @@ class MyOrderServiceTest {
 
             // then
             assertThat(result.orders()).hasSize(1);
-            verify(orderRepository).findConfirmedOrdersWithDetails(eq(MEMBER_ID), any(Pageable.class));
+            verify(orderRepository).findMyOrdersWithDetails(eq(MEMBER_ID), eq("confirmed"), any(Pageable.class));
         }
 
         @Test
@@ -169,10 +167,10 @@ class MyOrderServiceTest {
             Page<Order> orderPage = new PageImpl<>(List.of(testOrder));
 
             given(memberRepository.existsById(MEMBER_ID)).willReturn(true);
-            given(orderRepository.countInProgressOrders(MEMBER_ID)).willReturn(0L);
-            given(orderRepository.countConfirmedOrders(MEMBER_ID)).willReturn(0L);
-            given(orderRepository.countRefundPendingOrders(MEMBER_ID)).willReturn(1L);
-            given(orderRepository.findRefundPendingOrdersWithDetails(eq(MEMBER_ID), any(Pageable.class)))
+            given(orderRepository.countMyOrders(MEMBER_ID, "inprogress")).willReturn(0L);
+            given(orderRepository.countMyOrders(MEMBER_ID, "confirmed")).willReturn(0L);
+            given(orderRepository.countMyOrders(MEMBER_ID, "refundpending")).willReturn(1L);
+            given(orderRepository.findMyOrdersWithDetails(eq(MEMBER_ID), eq("refundpending"), any(Pageable.class)))
                     .willReturn(orderPage);
             given(refundItemRepository.existsByOrderItemIdAndRefundStatusIn(anyLong(), any())).willReturn(false);
             given(paymentRepository.findByOrderId(ORDER_ID)).willReturn(Optional.of(testPayment));
@@ -187,7 +185,7 @@ class MyOrderServiceTest {
 
             // then
             assertThat(result.orders()).hasSize(1);
-            verify(orderRepository).findRefundPendingOrdersWithDetails(eq(MEMBER_ID), any(Pageable.class));
+            verify(orderRepository).findMyOrdersWithDetails(eq(MEMBER_ID), eq("refundpending"), any(Pageable.class));
         }
 
         @Test
@@ -203,7 +201,7 @@ class MyOrderServiceTest {
                     .isEqualTo(ErrorCode.MEMBER_NOT_FOUND);
 
             verify(memberRepository).existsById(MEMBER_ID);
-            verify(orderRepository, never()).findAllOrdersWithDetails(anyLong(), any(Pageable.class));
+            verify(orderRepository, never()).findMyOrdersWithDetails(anyLong(), anyString(), any(Pageable.class));
         }
 
         @Test
@@ -213,10 +211,10 @@ class MyOrderServiceTest {
             Page<Order> orderPage = new PageImpl<>(List.of(testOrder));
 
             given(memberRepository.existsById(MEMBER_ID)).willReturn(true);
-            given(orderRepository.countInProgressOrders(MEMBER_ID)).willReturn(1L);
-            given(orderRepository.countConfirmedOrders(MEMBER_ID)).willReturn(0L);
-            given(orderRepository.countRefundPendingOrders(MEMBER_ID)).willReturn(0L);
-            given(orderRepository.findAllOrdersWithDetails(eq(MEMBER_ID), any(Pageable.class)))
+            given(orderRepository.countMyOrders(MEMBER_ID, "inprogress")).willReturn(1L);
+            given(orderRepository.countMyOrders(MEMBER_ID, "confirmed")).willReturn(0L);
+            given(orderRepository.countMyOrders(MEMBER_ID, "refundpending")).willReturn(0L);
+            given(orderRepository.findMyOrdersWithDetails(eq(MEMBER_ID), eq("all"), any(Pageable.class)))
                     .willReturn(orderPage);
             given(refundItemRepository.existsByOrderItemIdAndRefundStatusIn(anyLong(), any())).willReturn(false);
             given(paymentRepository.findByOrderId(ORDER_ID)).willReturn(Optional.of(testPayment));
@@ -231,7 +229,7 @@ class MyOrderServiceTest {
 
             // then
             assertThat(result.orders()).hasSize(1);
-            verify(orderRepository).findAllOrdersWithDetails(eq(MEMBER_ID), any(Pageable.class));
+            verify(orderRepository).findMyOrdersWithDetails(eq(MEMBER_ID), eq("all"), any(Pageable.class));
         }
 
         @Test
@@ -241,10 +239,10 @@ class MyOrderServiceTest {
             Page<Order> emptyPage = new PageImpl<>(List.of());
 
             given(memberRepository.existsById(MEMBER_ID)).willReturn(true);
-            given(orderRepository.countInProgressOrders(MEMBER_ID)).willReturn(0L);
-            given(orderRepository.countConfirmedOrders(MEMBER_ID)).willReturn(0L);
-            given(orderRepository.countRefundPendingOrders(MEMBER_ID)).willReturn(0L);
-            given(orderRepository.findAllOrdersWithDetails(eq(MEMBER_ID), any(Pageable.class)))
+            given(orderRepository.countMyOrders(MEMBER_ID, "inprogress")).willReturn(0L);
+            given(orderRepository.countMyOrders(MEMBER_ID, "confirmed")).willReturn(0L);
+            given(orderRepository.countMyOrders(MEMBER_ID, "refundpending")).willReturn(0L);
+            given(orderRepository.findMyOrdersWithDetails(eq(MEMBER_ID), eq("all"), any(Pageable.class)))
                     .willReturn(emptyPage);
 
             // when

--- a/src/test/java/com/ururulab/ururu/payment/service/PaymentServiceTest.java
+++ b/src/test/java/com/ururulab/ururu/payment/service/PaymentServiceTest.java
@@ -90,8 +90,8 @@ class PaymentServiceTest {
     private static final Long MEMBER_ID = 1L;
     private static final String ORDER_ID = "ORDER123";
     private static final String PAYMENT_KEY = "PAYMENT_KEY_123";
-    private static final Integer TOTAL_AMOUNT = 18000;
-    private static final Integer PAYMENT_AMOUNT = 13000;
+    private static final Integer TOTAL_AMOUNT = 15000;
+    private static final Integer PAYMENT_AMOUNT = 10000;
     private static final Integer USE_POINTS = 5000;
     private static final Integer MEMBER_POINTS = 10000;
 


### PR DESCRIPTION
## ⭐️ Issue Number
- #193 

## 🚩 Summary
- 주문 목록에서 환불 신청 정보를 확인할 수 있는 기능과 무료 배송 정책 구현
- QueryDSL 도입을 통한 주문 조회 성능 개선 및 복잡한 쿼리 로직 통합
- 환불 상태 판정 로직 개선으로 더 정확한 주문 상태 표시

## 🛠️ Technical Concerns

### 1. QueryDSL 도입 배경 및 기술적 필요성
- **기존 문제점**: `OrderRepository`에 상태별로 중복된 복잡한 JPQL 쿼리 다수 존재
  - `findInProgressOrdersWithDetails`, `findConfirmedOrdersWithDetails`, `findRefundPendingOrdersWithDetails` 등
  - 환불 상태에 따른 복잡한 서브쿼리와 조건문으로 인한 가독성 저하
  - 동일한 조인 패턴과 필터링 로직의 반복으로 유지보수성 악화
- **QueryDSL 선택 이유**: 
  - 타입 안전성으로 컴파일 타임 쿼리 검증 가능
  - 동적 쿼리 구성으로 조건별 분기를 하나의 메서드로 통합
  - 복잡한 서브쿼리를 자바 코드로 표현하여 가독성 향상
  - 향후 검색 조건 추가 시 확장성 확보

### 2. 환불  신청 정보 표시 구조
- `MyOrderResponseDto`에 `refundType`, `refundReason` 필드 추가
- `RefundRepository.findActiveRefundByOrderId()`로 INITIATED 상태 환불 조회
- 주문 목록 조회 시 진행중인 환불 정보를 함께 제공하여 사용자 경험 개선

### 3. 환불 상태 판정 로직 개선
- 기존 `isNotRefunded()` → `isRefundProcessed()`로 메서드명 명확화
- 환불 처리 완료 상태(`APPROVED`, `COMPLETED`, `REJECTED`, `FAILED`)와 미처리 상태 구분 명확화
- `MyOrderService`의 금액 계산 및 아이템 필터링 로직 정확성 향상

### 4. 무료 배송 정책 적용
- 사용자 혜택 확대를 위한 배송비 0원 정책 도입
- `OrderCreationService`, `PaymentService`에서 배송비 계산 로직 일괄 변경

## 🙂 To Reviewer
- QueryDSL 도입으로 인한 코드 복잡도 변화와 장기적 유지보수성 개선 효과 검토 요청
- 무료 배송 정책 변경이 다른 결제 관련 로직에 영향을 주지 않는지 확인 요청

## 📋 To Do
- [ ] 자동 환불 처리 추가
- [ ] PG 연결