### PR TITLE
결제 실패 시 cancelledAt 설정 및 환불 처리 순서 수정

### DIFF
--- a/src/main/java/com/ururulab/ururu/payment/domain/entity/Payment.java
+++ b/src/main/java/com/ururulab/ururu/payment/domain/entity/Payment.java
@@ -168,6 +168,7 @@ public class Payment extends BaseEntity {
         }
 
         this.status = PaymentStatus.FAILED;
+        this.cancelledAt = Instant.now();
     }
 
     public void markAsPartialRefunded() {

--- a/src/main/java/com/ururulab/ururu/payment/service/RefundService.java
+++ b/src/main/java/com/ururulab/ururu/payment/service/RefundService.java
@@ -46,7 +46,6 @@ public class RefundService {
     private final MemberRepository memberRepository;
     private final GroupBuyOptionRepository groupBuyOptionRepository;
     private final PointTransactionRepository pointTransactionRepository;
-    private final PaymentService paymentService;
 
     /**
      * 수동 환불 요청을 생성합니다.
@@ -139,7 +138,7 @@ public class RefundService {
 
     /**
      * 환불 승인 처리 로직을 수행합니다.
-     * 포인트 복구, 재고 복구, 주문/결제 상태 업데이트, PG 환불 요청을 순차적으로 처리합니다.
+     * 포인트 복구, 재고 복구, PG 환불 요청, 주문/결제 상태 업데이트를 순차적으로 처리합니다.
      *
      * @param refund 승인 처리할 환불 엔티티
      * @return 승인 처리 결과
@@ -149,8 +148,8 @@ public class RefundService {
 
         restorePointsToCustomer(refund);
         restoreStockToInventory(refund);
-        updateOrderAndPaymentStatus(refund);
         requestPgRefund(refund);
+        updateOrderAndPaymentStatus(refund);
 
         log.debug("환불 승인 처리 완료 - 환불ID: {}", refund.getId());
 
@@ -239,7 +238,7 @@ public class RefundService {
         Order order = payment.getOrder();
 
         order.changeStatus(OrderStatus.REFUNDED, "수동 환불 완료");
-        payment.markAsRefunded(Instant.now());
+        refund.markAsCompleted(Instant.now());
 
         log.debug("주문/결제 상태 업데이트 완료 - 주문ID: {}", order.getId());
     }


### PR DESCRIPTION
## ⭐️ Issue Number
- #198

## 🚩 Summary
- 결제 실패 시 cancelledAt 시점 기록하도록 수정 (Payment.markAsFailed)
- PG 환불 요청을 상태 업데이트보다 먼저 실행하도록 순서 변경
- Payment 상태 변경 대신 Refund 상태만 업데이트하도록 수정

## 🛠️ Technical Concerns
- “결제 취소”, “환불”, “실패” 같은 표현은 정확하게 구분된 도메인 용어로 통일할 것
→ 비즈니스 흐름 상 명확한 책임 주체와 시점을 나타내는 용어 중요함

## 🙂 To Reviewer
- 작은 변경사항이라 간단한 확인 부탁드립니다 

## 📋 To Do
- [ ] PG 환불 API 연동