### PR TITLE
공동구매 최소 수량 검증 수정

### DIFF
--- a/src/main/java/com/ururulab/ururu/global/exception/error/ErrorCode.java
+++ b/src/main/java/com/ururulab/ururu/global/exception/error/ErrorCode.java
@@ -112,7 +112,7 @@ public enum ErrorCode {
 	DISCOUNT_RATE_REQUIRED(HttpStatus.BAD_REQUEST, "GROUPBUY015", "할인율은 필수입니다."),
 	MIN_QUANTITY_REQUIRED(HttpStatus.BAD_REQUEST, "GROUPBUY016", "최소 달성 수량은 필수입니다."),
 	DISCOUNT_RATE_OUT_OF_RANGE(HttpStatus.BAD_REQUEST, "GROUPBUY017", "할인율은 0~100% 사이여야 합니다."),
-	MIN_QUANTITY_OUT_OF_RANGE(HttpStatus.BAD_REQUEST, "GROUPBUY018", "최소 달성 수량은 1 이상 10,000 이하여야 합니다."),
+	MIN_QUANTITY_OUT_OF_RANGE(HttpStatus.BAD_REQUEST, "GROUPBUY018", "최소 달성 수량은 1 이상 9,999,999 이하여야 합니다."),
 	DUPLICATE_DISCOUNT_STAGE(HttpStatus.BAD_REQUEST, "GROUPBUY019", "동일한 최소 수량의 할인 단계가 중복됩니다."),
 	EXCEEDED_DISCOUNT_STAGE_LIMIT(HttpStatus.BAD_REQUEST, "GROUPBUY020", "할인 단계는 최대 10개까지 설정할 수 있습니다."),
 	DISCOUNT_STAGE_EXCEEDS_STOCK(HttpStatus.BAD_REQUEST, "GROUPBUY021", "재고량보다 많은 최소 수량이 설정되어 있습니다."),

--- a/src/main/java/com/ururulab/ururu/groupBuy/dto/validation/GroupBuyValidationConstants.java
+++ b/src/main/java/com/ururulab/ururu/groupBuy/dto/validation/GroupBuyValidationConstants.java
@@ -15,6 +15,7 @@ public class GroupBuyValidationConstants {
     // 할인 제한
     public static final int LIMIT_RATE_MIN = 0;
     public static final int LIMIT_RATE_MAX = 100;
+    public static final int LIMIT_REWARD_QUANTITY_MAX = 9999999;
 
     // 이미지 관련
     public static final int MAX_GROUP_BUY_THUMBNAIL_IMAGES = 1;

--- a/src/main/java/com/ururulab/ururu/groupBuy/service/validation/GroupBuyDiscountStageValidator.java
+++ b/src/main/java/com/ururulab/ururu/groupBuy/service/validation/GroupBuyDiscountStageValidator.java
@@ -49,7 +49,7 @@ public class GroupBuyDiscountStageValidator {
             throw new BusinessException(MIN_QUANTITY_REQUIRED);
         }
 
-        if (minQuantity < 1 || minQuantity > LIMIT_QUANTITY_MAX) {
+        if (minQuantity < 1 || minQuantity > LIMIT_REWARD_QUANTITY_MAX) {
             throw new BusinessException(MIN_QUANTITY_OUT_OF_RANGE);
         }
     }


### PR DESCRIPTION
## ⭐️ Issue Number
- #201 

## 🚩 Summary
- 최소 참여 인원 최대 상수 생성
- 공동구매 리워드 단계에서 최소 참여 인원 검증에 대한 조건문 수정
- 에러 코드 수정

## 🛠️ Technical Concerns


## 🙂 To Reviewer
최소 구매 인원과 물품을 1대 1로 보고 있기 때문에 물품의 최대 구매 인원 검증할 때 재고의 최대 제한 수와 같아야 합니다. 그래서 이 부분에 대해서 수정했습니다.

## 📋 To Do

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 최소 수량의 허용 최대값이 10,000에서 9,999,999로 상향 조정되어, 더 큰 수량 입력이 가능해졌습니다.  
* **신규 기능**
  * 리워드 수량의 최대 한도 상수가 추가되어, 관련 검증에 적용되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->