### PR TITLE
PayMethod enum 구조 개선 및 EASY_PAY 통합

### DIFF
--- a/src/main/java/com/ururulab/ururu/payment/domain/entity/enumerated/PayMethod.java
+++ b/src/main/java/com/ururulab/ururu/payment/domain/entity/enumerated/PayMethod.java
@@ -3,19 +3,21 @@ package com.ururulab.ururu.payment.domain.entity.enumerated;
 public enum PayMethod {
     CARD,       // 카드 결제
     TRANSFER,   // 계좌이체
-    TOSS_PAY;   // 토스페이
+    EASY_PAY;   // 간편결제 (토스페이, 카카오페이 등 모두 포함)
 
     public static PayMethod from(String method, String easyPayProvider) {
         if (method == null) {
             throw new IllegalArgumentException("결제 방식은 필수입니다.");
         }
+
         if ("카드".equals(method) && easyPayProvider == null) {
             return CARD;
         } else if ("계좌이체".equals(method) && easyPayProvider == null) {
             return TRANSFER;
-        } else if ("카드".equals(method) && "토스페이".equals(easyPayProvider)) {
-            return TOSS_PAY;
+        } else if ("간편결제".equals(method)) {
+            return EASY_PAY;  // 간편결제는 모두 하나로 처리
         }
+
         throw new IllegalArgumentException("알 수 없는 결제 방식: " + method + ", " + easyPayProvider);
     }
 }


### PR DESCRIPTION
## ⭐️ Issue Number
- #209

## 🚩 Summary
- `TOSS_PAY` enum 항목 제거
- 간편결제를 `EASY_PAY` 하나로 통합하여 enum 구조 간소화
- `PayMethod.from()`에서 `"간편결제"` 문자열 기반으로 EASY\_PAY 반환

## 🛠️ Technical Concerns
-기존 방식은 간편결제 수단이 추가될 때마다 enum 항목을 직접 확장해야 했기 때문에 유지보수 및 확장성이 낮음
- 이번 리팩토링으로 enum 구조를 단순화하고, 다양한 간편결제 수단을 유연하게 도입할 수 있는 기반을 마련

## 🙂 To Reviewer
- 결제 수단 enum 구조를 수정였으니 간단히 확인 부탁드립니다 🙏

## 📋 To Do
- [ ] PG 환불 API 연동

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 다양한 간편결제 수단(토스페이, 카카오페이 등)을 하나의 '간편결제' 방식으로 통합하여 선택할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->