### PR TITLE
공동구매 삭제 시 상품 상태 변경 로직 추가

### DIFF
--- a/src/main/java/com/ururulab/ururu/groupBuy/scheduler/GroupBuyBatchScheduler.java
+++ b/src/main/java/com/ururulab/ururu/groupBuy/scheduler/GroupBuyBatchScheduler.java
@@ -16,7 +16,7 @@ public class GroupBuyBatchScheduler {
     /**
      * 매일 자정(00:00)에 만료된 공동구매 배치 종료
      */
-    @Scheduled(cron = "0 0 0 * * *")
+    @Scheduled(cron = "0 0 0 * * *",  zone = "Asia/Seoul")
     public void closeExpiredGroupBuysBatch() {
         log.info("Starting daily batch process for expired group buys...");
 
@@ -34,7 +34,7 @@ public class GroupBuyBatchScheduler {
      * 시간별 헬스체크용
      * 매 시간마다 급하게 처리해야 할 만료된 공동구매가 있는지 확인
      */
-    @Scheduled(cron = "0 0 * * * *") // 매시간 정각
+    @Scheduled(cron = "0 0 * * * *", zone = "Asia/Seoul") // 매시간 정각
     public void hourlyHealthCheck() {
         log.debug("Running hourly health check for group buy expiration...");
 

--- a/src/main/java/com/ururulab/ururu/groupBuy/service/GroupBuyBatchCloseService.java
+++ b/src/main/java/com/ururulab/ururu/groupBuy/service/GroupBuyBatchCloseService.java
@@ -6,6 +6,8 @@ import com.ururulab.ururu.groupBuy.domain.entity.enumerated.GroupBuyStatus;
 import com.ururulab.ururu.groupBuy.domain.repository.GroupBuyRepository;
 import com.ururulab.ururu.groupBuy.domain.repository.GroupBuyStatisticsRepository;
 import com.ururulab.ururu.groupBuy.event.GroupBuysBatchClosedEvent;
+import com.ururulab.ururu.product.domain.entity.Product;
+import com.ururulab.ururu.product.domain.entity.enumerated.Status;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.ApplicationEventPublisher;
@@ -88,6 +90,13 @@ public class GroupBuyBatchCloseService {
             try {
                 // 상태를 CLOSED로 변경
                 groupBuy.updateStatus(GroupBuyStatus.CLOSED);
+
+                // 연관된 상품을 INACTIVE로 변경
+                Product product = groupBuy.getProduct();
+                if (product.getStatus() == Status.ACTIVE) {
+                    product.updateStatus(Status.INACTIVE);
+                    log.info("Product {} deactivated after GroupBuy deletion", product.getId());
+                }
 
                 // 최종 할인율이 있으면 최종 판매가 업데이트
                 if (statistics.getFinalDiscountRate() > 0) {

--- a/src/main/java/com/ururulab/ururu/groupBuy/service/GroupBuyDeleteService.java
+++ b/src/main/java/com/ururulab/ururu/groupBuy/service/GroupBuyDeleteService.java
@@ -7,8 +7,10 @@ import com.ururulab.ururu.groupBuy.domain.repository.GroupBuyOptionRepository;
 import com.ururulab.ururu.groupBuy.domain.repository.GroupBuyRepository;
 import com.ururulab.ururu.groupBuy.event.GroupBuyDetailImageDeleteEvent;
 import com.ururulab.ururu.groupBuy.event.GroupBuyThumbnailDeleteEvent;
+import com.ururulab.ururu.product.domain.entity.Product;
 import com.ururulab.ururu.product.domain.entity.enumerated.Status;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -20,6 +22,7 @@ import static com.ururulab.ururu.global.exception.error.ErrorCode.*;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class GroupBuyDeleteService {
 
     private final GroupBuyRepository groupBuyRepository;
@@ -37,6 +40,13 @@ public class GroupBuyDeleteService {
 
         if (groupBuy.getStatus() != GroupBuyStatus.DRAFT) {
             throw new BusinessException(GROUPBUY_DELETE_NOT_ALLOWED);
+        }
+
+        // 연관된 상품을 INACTIVE로 변경
+        Product product = groupBuy.getProduct();
+        if (product.getStatus() == Status.ACTIVE) {
+            product.updateStatus(Status.INACTIVE);
+            log.info("Product {} deactivated after GroupBuy deletion", product.getId());
         }
 
         // 1. 썸네일 이미지 삭제 이벤트 발행

--- a/src/main/java/com/ururulab/ururu/groupBuy/service/GroupBuyRealtimeCloseService.java
+++ b/src/main/java/com/ururulab/ururu/groupBuy/service/GroupBuyRealtimeCloseService.java
@@ -7,6 +7,8 @@ import com.ururulab.ururu.groupBuy.domain.entity.enumerated.GroupBuyStatus;
 import com.ururulab.ururu.groupBuy.domain.repository.GroupBuyOptionRepository;
 import com.ururulab.ururu.groupBuy.domain.repository.GroupBuyRepository;
 import com.ururulab.ururu.groupBuy.domain.repository.GroupBuyStatisticsRepository;
+import com.ururulab.ururu.product.domain.entity.Product;
+import com.ururulab.ururu.product.domain.entity.enumerated.Status;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -81,6 +83,13 @@ public class GroupBuyRealtimeCloseService {
 
         // 상태를 CLOSED로 변경
         groupBuy.updateStatus(GroupBuyStatus.CLOSED);
+
+        // 연관된 상품을 INACTIVE로 변경
+        Product product = groupBuy.getProduct();
+        if (product.getStatus() == Status.ACTIVE) {
+            product.updateStatus(Status.INACTIVE);
+            log.info("Product {} deactivated after GroupBuy deletion", product.getId());
+        }
 
         // 최종 할인율이 있으면 최종 판매가 업데이트
         if (statistics.getFinalDiscountRate() > 0) {


### PR DESCRIPTION
## ⭐️ Issue Number
- #213

## 🚩 Summary
- 공구 삭제 및 CLOSED 변경 상품 상태 INACTIVE로 비활성화
- 이를 통해 상품은 공동구매가 끝나거나 삭제했을 때도 다시 공동구매에 등록 가능

## 🛠️ Technical Concerns


## 🙂 To Reviewer
삭제했을 때도 다시 공동구매에 등록 가능하도록 status 변경 로직 추가했습니다

## 📋 To Do