### PR TITLE
장바구니 일괄 아이템 추가 기능 구현

### DIFF
--- a/src/main/java/com/ururulab/ururu/order/controller/CartController.java
+++ b/src/main/java/com/ururulab/ururu/order/controller/CartController.java
@@ -19,6 +19,8 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
+
 @Slf4j
 @RestController
 @RequestMapping("/api/cart")
@@ -37,17 +39,19 @@ public class CartController {
             @ApiResponse(responseCode = "409", description = "종료된 공구")
     })
     @PostMapping("/items")
-    public ResponseEntity<ApiResponseFormat<CartItemAddResponse>> addCartItem(
+    public ResponseEntity<ApiResponseFormat<List<CartItemAddResponse>>> addCartItems(
             @AuthenticationPrincipal Long memberId,
-            @Valid @RequestBody CartItemAddRequest request
+            @Valid @RequestBody List<CartItemAddRequest> requests
     ) {
-        log.debug("장바구니 아이템 추가 요청 - 회원ID: {}, 요청: {}", memberId, request);
+        log.debug("장바구니 아이템 추가 요청 - 회원ID: {}, 요청: {}", memberId, requests);
 
-        CartItemAddResponse response = cartService.addCartItem(memberId, request);
+        List<CartItemAddResponse> responses = requests.stream()
+                .map(request -> cartService.addCartItem(memberId, request))
+                .toList();
 
         return ResponseEntity
                 .status(HttpStatus.CREATED)
-                .body(ApiResponseFormat.success("장바구니에 추가되었습니다", response));
+                .body(ApiResponseFormat.success("장바구니에 추가되었습니다", responses));
     }
 
     @Operation(summary = "장바구니 조회", description = "회원의 장바구니를 조회합니다. 만료된 공구는 자동으로 제외됩니다.")


### PR DESCRIPTION
## ⭐️ Issue Number
- #215

## 🚩 Summary
- `POST /api/cart/items` API를 배열 형태로 변경
- `List<CartItemAddRequest>` 요청으로 여러 아이템 동시 추가 지원
- 응답도 `List<CartItemAddResponse>`로 변경하여 일괄 처리 결과 제공

## 🛠️ Technical Concerns
- 기존 방식은 아이템을 하나씩만 추가할 수 있어 여러 상품을 담을 때 API 호출이 반복되어 비효율적
- 이번 개선으로 한 번의 요청으로 여러 아이템을 추가할 수 있어 네트워크 비용 절감 및 사용자 경험 향상

## 🙂 To Reviewer
- 장바구니 API 구조를 단일에서 배열로 변경했으니 간단히 확인 부탁드립니다 🙏

## 📋 To Do
- [ ] PG 환불 API 연동

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 장바구니에 여러 상품을 한 번에 추가할 수 있는 기능이 도입되었습니다.

* **버그 수정**
  * 장바구니 추가 시 응답 형식이 일관되게 리스트로 반환되도록 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->